### PR TITLE
Use preexisting APIC external networks

### DIFF
--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_common.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_common.py
@@ -31,6 +31,8 @@ APIC_PWD = 'topsecret'
 
 APIC_TENANT = 'citizen14'
 APIC_NETWORK = 'network99'
+APIC_NETWORK_PRE = 'network_pre'
+APIC_EXT_EPG = 'external_epg'
 APIC_NETNAME = 'net99name'
 APIC_SUBNET = '10.3.2.1/24'
 APIC_L3CTX = 'layer3context'
@@ -217,6 +219,15 @@ class ConfigMixin(object):
                 'encap': APIC_EXT_ENCAP,
                 'cidr_exposed': APIC_EXT_CIDR_EXPOSED,
                 'gateway_ip': APIC_EXT_GATEWAY_IP,
+            },
+            APIC_NETWORK_PRE + '-name': {
+                'switch': APIC_EXT_SWITCH,
+                'port': APIC_EXT_MODULE + '/' + APIC_EXT_PORT,
+                'encap': APIC_EXT_ENCAP,
+                'cidr_exposed': APIC_EXT_CIDR_EXPOSED,
+                'gateway_ip': APIC_EXT_GATEWAY_IP,
+                'preexisting': True,
+                'external_epg': APIC_EXT_EPG,
             },
         }
         self.mocked_parser = mock.patch.object(

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -20,6 +20,7 @@ import mock
 sys.modules["apicapi"] = mock.Mock()
 sys.modules["opflexagent"] = mock.Mock()
 sys.modules["opflexagent"].constants.TYPE_OPFLEX = 'opflex'
+sys.modules["apicapi"].apic_manager.TENANT_COMMON = 'common'
 
 from neutron.common import constants as n_constants
 from neutron.extensions import portbindings
@@ -43,6 +44,10 @@ TEST_SEGMENT1 = 'test-segment1'
 TEST_SEGMENT2 = 'test-segment2'
 
 
+def echo(context, id):
+    return id
+
+
 class TestCiscoApicMechDriver(base.BaseTestCase,
                               mocked.ControllerMixin,
                               mocked.ConfigMixin):
@@ -58,11 +63,11 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         self.driver.vif_type = 'test-vif_type'
         self.driver.cap_port_filter = 'test-cap_port_filter'
         self.driver.name_mapper = mock.Mock()
-        self.driver.name_mapper.tenant.return_value = mocked.APIC_TENANT
-        self.driver.name_mapper.network.return_value = mocked.APIC_NETWORK
-        self.driver.name_mapper.subnet.return_value = mocked.APIC_SUBNET
-        self.driver.name_mapper.port.return_value = mocked.APIC_PORT
-        self.driver.name_mapper.router.return_value = mocked.APIC_ROUTER
+        self.driver.name_mapper.tenant = echo
+        self.driver.name_mapper.network = echo
+        self.driver.name_mapper.subnet = echo
+        self.driver.name_mapper.port = echo
+        self.driver.name_mapper.router = echo
         self.driver.name_mapper.app_profile.return_value = mocked.APIC_AP
         self.driver.apic_manager = mock.Mock(
             name_mapper=mock.Mock(), ext_net_dict=self.external_network_dict)
@@ -71,6 +76,17 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         self.agent = {'configurations': {
             'opflex_networks': None,
             'bridge_mappings': {'physnet1': 'br-eth1'}}}
+        mock.patch('neutron.manager.NeutronManager').start()
+
+    def _check_call_list(self, expected, observed):
+        for call in expected:
+            self.assertTrue(call in observed,
+                            msg='Call not found, expected:\n%s\nobserved:'
+                                '\n%s' % (str(call), str(observed)))
+            observed.remove(call)
+        self.assertFalse(
+            len(observed),
+            msg='There are more calls than expected: %s' % str(observed))
 
     def test_initialize(self):
         mgr = self.driver.apic_manager
@@ -179,6 +195,59 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
             mocked.APIC_NETWORK, mgr.get_router_contract.return_value,
             transaction='transaction')
 
+    def test_update_pre_gw_port_postcommit(self):
+        net_ctx = self._get_network_context(mocked.APIC_TENANT,
+                                            mocked.APIC_NETWORK_PRE,
+                                            TEST_SEGMENT1, external=True)
+        port_ctx = self._get_port_context(mocked.APIC_TENANT,
+                                          mocked.APIC_NETWORK_PRE,
+                                          'vm1', net_ctx, HOST_ID1, gw=True)
+        mgr = self.driver.apic_manager
+        mgr.get_router_contract.return_value = mocked.FakeDbContract(
+            mocked.APIC_CONTRACT)
+        self.driver.update_port_postcommit(port_ctx)
+        mgr.get_router_contract.assert_called_once_with(
+            port_ctx.current['device_id'])
+        mgr.ensure_context_enforced.assert_called_once()
+        self.assertFalse(mgr.ensure_external_routed_network_created.called)
+        self.assertFalse(mgr.ensure_logical_node_profile_created.called)
+        self.assertFalse(mgr.ensure_static_route_created.called)
+        self.assertFalse(mgr.ensure_external_epg_created.called)
+
+        mgr.ensure_external_epg_consumed_contract.assert_called_once_with(
+            mocked.APIC_NETWORK_PRE, mgr.get_router_contract.return_value,
+            transaction='transaction', external_epg=mocked.APIC_EXT_EPG)
+        mgr.ensure_external_epg_provided_contract.assert_called_once_with(
+            mocked.APIC_NETWORK_PRE, mgr.get_router_contract.return_value,
+            transaction='transaction', external_epg=mocked.APIC_EXT_EPG)
+
+    def test_delete_gw_port_postcommit(self):
+        net_ctx = self._get_network_context(mocked.APIC_TENANT,
+                                            mocked.APIC_NETWORK,
+                                            TEST_SEGMENT1, external=True)
+        port_ctx = self._get_port_context(mocked.APIC_TENANT,
+                                          mocked.APIC_NETWORK,
+                                          'vm1', net_ctx, HOST_ID1, gw=True)
+        self.driver._delete_path_if_last = mock.Mock()
+        self.driver.delete_port_postcommit(port_ctx)
+        mgr = self.driver.apic_manager
+        mgr.delete_external_epg_contract.assert_called_once_with(
+            mocked.APIC_ROUTER, mocked.APIC_NETWORK)
+
+    def test_delete_pre_gw_port_postcommit(self):
+        net_ctx = self._get_network_context(mocked.APIC_TENANT,
+                                            mocked.APIC_NETWORK_PRE,
+                                            TEST_SEGMENT1, external=True)
+        port_ctx = self._get_port_context(mocked.APIC_TENANT,
+                                          mocked.APIC_NETWORK_PRE,
+                                          'vm1', net_ctx, HOST_ID1, gw=True)
+        mgr = self.driver.apic_manager
+        self.driver._delete_path_if_last = mock.Mock()
+        self.driver.delete_port_postcommit(port_ctx)
+        mgr.delete_external_epg_contract.assert_called_once_with(
+            mocked.APIC_ROUTER, mocked.APIC_NETWORK_PRE,
+            external_epg=mocked.APIC_EXT_EPG)
+
     def test_update_gw_port_postcommit_fail_contract_create(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,
                                             mocked.APIC_NETWORK,
@@ -227,8 +296,22 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
                                         TEST_SEGMENT1, external=True)
         mgr = self.driver.apic_manager
         self.driver.delete_network_postcommit(ctx)
+
+        expected_calls = [
+            mock.call(mocked.APIC_NETWORK),
+            mock.call("Shd-%s" % ctx.current['name'], 'common',
+                      transaction=mock.ANY)]
+        self._check_call_list(
+            expected_calls, mgr.delete_external_routed_network.call_args_list)
+
+    def test_delete_pre_external_network_postcommit(self):
+        ctx = self._get_network_context(mocked.APIC_TENANT,
+                                        mocked.APIC_NETWORK_PRE,
+                                        TEST_SEGMENT1, external=True)
+        mgr = self.driver.apic_manager
+        self.driver.delete_network_postcommit(ctx)
         mgr.delete_external_routed_network.assert_called_once_with(
-            mocked.APIC_NETWORK)
+            "Shd-%s" % ctx.current['name'], 'common', transaction=mock.ANY)
 
     def test_create_subnet_postcommit(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,
@@ -345,25 +428,13 @@ class FakePortContext(object):
         else:
             self._bound_segment = None
 
-    @property
-    def current(self):
-        return self._port
-
-    @property
-    def network(self):
-        return self._network
-
-    @property
-    def bound_segment(self):
-        return self._bound_segment
+        self.current = self._port
+        self.network = self._network
+        self.bound_segment = self._bound_segment
+        self.host = self._port.get(portbindings.HOST_ID)
+        self.original_host = None
+        self._binding = mock.Mock()
+        self._binding.segment = self._bound_segment
 
     def set_binding(self, segment_id, vif_type, cap_port_filter):
         pass
-
-    @property
-    def host(self):
-        return self._port.get(portbindings.HOST_ID)
-
-    @property
-    def original_host(self):
-        return self._original_port.get(portbindings.HOST_ID)


### PR DESCRIPTION
(cherry picked from commit d6f16c6d573e38fbd31e8590a9845de179a115f9)

Conflicts:
    apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
