### PR TITLE
Use elevated context when retrieving ports

### DIFF
--- a/apic_ml2/neutron/services/l3_router/l3_apic.py
+++ b/apic_ml2/neutron/services/l3_router/l3_apic.py
@@ -77,7 +77,7 @@ class ApicL3ServicePlugin(db_base_plugin_v2.NeutronDbPluginV2,
         filters = {'device_id': [router_id],
                    'device_owner': [q_const.DEVICE_OWNER_ROUTER_INTF],
                    'fixed_ips': {'subnet_id': [subnet_id]}}
-        ports = self.get_ports(context, filters=filters)
+        ports = self.get_ports(context.elevated(), filters=filters)
         return ports[0]['id']
 
     def _update_router_gw_info(self, context, router_id, info, router=None):
@@ -87,7 +87,7 @@ class ApicL3ServicePlugin(db_base_plugin_v2.NeutronDbPluginV2,
             filters = {'device_id': [router_id],
                        'device_owner': [q_const.DEVICE_OWNER_ROUTER_GW],
                        'network_id': [info['network_id']]}
-            ports = self.get_ports(context, filters=filters)
+            ports = self.get_ports(context.elevated(), filters=filters)
             manager.NeutronManager.get_plugin().update_port_status(
                 context, ports[0]['id'], q_const.PORT_STATUS_ACTIVE)
 


### PR DESCRIPTION
External gateway ports are created as admin, hence need elevated
context for retrieval.
