### PR TITLE
Fix for Hierarchical Port Binding patch.

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -330,7 +330,7 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
         def is_port_promiscuous(port):
             return port['device_owner'] == n_constants.DEVICE_OWNER_DHCP
 
-        segment = port_context.bound_segment or {}
+        segment = port_context.top_bound_segment or {}
         details = {'device': kwargs.get('device'),
                    'port_id': port_id,
                    'mac_address': port['mac_address'],
@@ -568,13 +568,13 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
                 context, network['id'], openstack_owner=network['tenant_id'])
             epg_name = self._get_ext_epg_for_ext_net(l3out_name)
         # Get segmentation id
-        if not context.bound_segment:
+        if not context.top_bound_segment:
             LOG.debug("Port %s is not bound to a segment", port)
             return
         seg = None
-        if (context.bound_segment.get(api.NETWORK_TYPE)
+        if (context.top_bound_segment.get(api.NETWORK_TYPE)
                 in [constants.TYPE_VLAN]):
-            seg = context.bound_segment.get(api.SEGMENTATION_ID)
+            seg = context.top_bound_segment.get(api.SEGMENTATION_ID)
         # hosts on which this vlan is provisioned
         host = context.host
         # Create a static path attachment for the host/epg/switchport combo

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -1823,7 +1823,7 @@ class FakePortContext(object):
 
         self.current = self._port
         self.network = self._network
-        self.bound_segment = self._bound_segment
+        self.top_bound_segment = self._bound_segment
         self.host = self._port.get(portbindings.HOST_ID)
         self.original_host = None
         self._binding = mock.Mock()


### PR DESCRIPTION
This change updates the mechanism driver to be compatible
with the change in Icb1a016f4661e427cb6cfa3452802ba5e64b7124
for Hierarchical Port Bindings.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
