### PR TITLE
Prevent unnecessary error message for SNAT network

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -32,6 +32,7 @@ from neutron import manager
 from neutron.openstack.common import lockutils
 from neutron.openstack.common import log
 from neutron.plugins.common import constants
+from neutron.plugins.ml2 import db as ml2_db
 from neutron.plugins.ml2 import driver_api as api
 from neutron.plugins.ml2 import driver_context
 from neutron.plugins.ml2.drivers.cisco.apic import apic_model
@@ -1146,6 +1147,10 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
                              'status': n_constants.NET_STATUS_DOWN}}
         snat_network = self.db_plugin.create_network(
             context._plugin_context, attrs)
+        segment = {api.NETWORK_TYPE: constants.TYPE_LOCAL}
+        ml2_db.add_network_segment(context._plugin_context.session,
+                                   snat_network['id'], segment)
+
         if not snat_network:
             LOG.warning(_("SNAT network %(name)s creation failed for "
                           "external network %(net_id)s. SNAT "

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -32,6 +32,7 @@ from neutron.db import db_base_plugin_v2  # noqa
 from neutron.db import models_v2  # noqa
 from neutron.extensions import portbindings
 from neutron import manager
+from neutron.plugins.ml2 import db as ml2_db
 from neutron.plugins.ml2 import driver_context
 from neutron.plugins.ml2.drivers import type_vlan  # noqa
 from neutron.tests import base
@@ -1766,7 +1767,10 @@ class TestCiscoApicMechDriverHostSNAT(ApicML2IntegratedTestBase):
         snat_networks = self.driver.db_plugin.get_networks(
             ctx,
             filters={'name': [self.driver._get_snat_db_network_name(db_net)]})
+        snat_net_id = snat_networks[0]['id']
         self.assertEqual(1, len(snat_networks))
+        seg = ml2_db.get_network_segments(ctx.session, snat_net_id)
+        self.assertEqual(1, len(seg))
         subnets = self.driver.db_plugin.get_subnets(
             ctx, filters={'name': [acst.HOST_SNAT_POOL]})
         self.assertEqual(1, len(subnets))
@@ -1775,6 +1779,8 @@ class TestCiscoApicMechDriverHostSNAT(ApicML2IntegratedTestBase):
             ctx,
             filters={'name': [self.driver._get_snat_db_network_name(db_net)]})
         self.assertEqual(0, len(snat_networks))
+        seg = ml2_db.get_network_segments(ctx.session, snat_net_id)
+        self.assertEqual(0, len(seg))
         subnets = self.driver.db_plugin.get_subnets(
             ctx, filters={'name': [acst.HOST_SNAT_POOL]})
         self.assertEqual(0, len(subnets))


### PR DESCRIPTION
Whenever a get_network operation is performed in the admin
context, the ML2 plugin returns the details of the DB-only SNAT
network(s). While constructing the network details the following
method is invoked:
https://github.com/openstack/neutron/blob/6c38103e095dbf107bdb199979be8e5e909d7e74/neutron/plugins/ml2/managers.py#L123-L130

which logs an error if there is no segment associated with a network.

The SNAT network does not require a segment, however we create a
local segment in this patch to comply with the above ML2 requirement
and avoid the error message in the logs.
