### PR TITLE
Support allocating host SNAT IPs from user created subnets

### DIFF
--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_common.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_common.py
@@ -94,7 +94,7 @@ SERVICE_PEER_PORT_LOCAL = 'Eth%s/%s' % (APIC_EXT_MODULE, APIC_EXT_PORT)
 SERVICE_PEER_PORT_DESC = ('topology/pod-1/paths-%s/pathep-[%s]' %
                           (APIC_EXT_SWITCH, SERVICE_PEER_PORT_LOCAL.lower()))
 
-HOST_POOL_CIDR = "192.168.0.1/24"
+HOST_POOL_CIDR = "192.168.0.1/30"
 
 
 class ControllerMixin(object):

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -26,6 +26,7 @@ sys.modules["opflexagent"] = mock.Mock()
 sys.modules["opflexagent"].constants.TYPE_OPFLEX = 'opflex'
 import netaddr
 from neutron.api import extensions
+from neutron.api.v2 import attributes
 from neutron.common import constants as n_constants
 from neutron import context
 from neutron.db import db_base_plugin_v2  # noqa
@@ -1766,10 +1767,10 @@ class TestCiscoApicMechDriverHostSNAT(ApicML2IntegratedTestBase):
             self.assertEqual(1, len(host_snat_ips))
             self.assertEqual(db_net['name'],
                              host_snat_ips[0]['external_segment_name'])
-            self.assertEqual('192.168.0.2',
-                             host_snat_ips[0]['host_snat_ip'])
             self.assertEqual('192.168.0.1',
                              host_snat_ips[0]['gateway_ip'])
+            self.assertEqual('192.168.0.2',
+                             host_snat_ips[0]['host_snat_ip'])
             self.assertEqual(
                 netaddr.IPNetwork(mocked.HOST_POOL_CIDR).prefixlen,
                 host_snat_ips[0]['prefixlen'])
@@ -1791,10 +1792,10 @@ class TestCiscoApicMechDriverHostSNAT(ApicML2IntegratedTestBase):
                 self.assertEqual(1, len(host_snat_ips))
                 self.assertEqual(db_net['name'],
                                  host_snat_ips[0]['external_segment_name'])
-                self.assertEqual('192.168.0.2',
-                                 host_snat_ips[0]['host_snat_ip'])
                 self.assertEqual('192.168.0.1',
                                  host_snat_ips[0]['gateway_ip'])
+                self.assertEqual('192.168.0.2',
+                                 host_snat_ips[0]['host_snat_ip'])
                 self.assertEqual(
                     netaddr.IPNetwork(mocked.HOST_POOL_CIDR).prefixlen,
                     host_snat_ips[0]['prefixlen'])
@@ -1803,6 +1804,24 @@ class TestCiscoApicMechDriverHostSNAT(ApicML2IntegratedTestBase):
                                   'network_id': [snat_network_id],
                                   'device_id': ['h1']})
                 self.assertEqual(1, len(snat_ports))
+            # The IPs on the automatically created subnet corresponding
+            # to the host_pool_cidr have now been exhausted. We create
+            # a new subnet on the SNAT network, and test whether the
+            # IPs for a new SNAT port will be allocated from this new
+            # subnet.
+            attrs = {'subnet': {'name': 'something',
+                                'cidr': '192.168.1.1/30',
+                                'network_id': snat_network_id,
+                                'ip_version': 4,
+                                'enable_dhcp': False,
+                                'gateway_ip': attributes.ATTR_NOT_SPECIFIED,
+                                'allocation_pools':
+                                attributes.ATTR_NOT_SPECIFIED,
+                                'dns_nameservers':
+                                attributes.ATTR_NOT_SPECIFIED,
+                                'host_routes':
+                                attributes.ATTR_NOT_SPECIFIED}}
+            self.actual_core_plugin.create_subnet(ctx, attrs)
             # Now simulate event of a second host
             host_arg = {'binding:host_id': 'h2'}
             with self.port(subnet=sub, tenant_id='anothertenant',
@@ -1816,9 +1835,9 @@ class TestCiscoApicMechDriverHostSNAT(ApicML2IntegratedTestBase):
                 self.assertEqual(1, len(host_snat_ips))
                 self.assertEqual(db_net['name'],
                                  host_snat_ips[0]['external_segment_name'])
-                self.assertEqual('192.168.0.3',
+                self.assertEqual('192.168.1.2',
                                  host_snat_ips[0]['host_snat_ip'])
-                self.assertEqual('192.168.0.1',
+                self.assertEqual('192.168.1.1',
                                  host_snat_ips[0]['gateway_ip'])
                 self.assertEqual(
                     netaddr.IPNetwork(mocked.HOST_POOL_CIDR).prefixlen,


### PR DESCRIPTION
The host SNAT auto IP allocation feature creates a SNAT subnet
on a SNAT network based on the CIDR in the host_pool_cidr configuration.
However, if this CIDR is exhausted, there is no way to add more subnet(s).

With this patch, the user will be able to create additional subnet(s) on
the SNAT network (the ones which have a name prefix
"host-snat-network-for-internal-use-"). Once this subnet is created
successfully, the host SNAT IPs will continue to be allocated from the newly
added subnet(s).

Note that these user defined subnet(s) should always have a gateway IP set,
so the "no-gateway" option should not be chosen when creating them.
