### PR TITLE
Send correct host SNAT IP in get_dbp_details

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -346,7 +346,7 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
         if port['device_owner'].startswith('compute:') and port['device_id']:
             vm = nova_client.NovaClient().get_server(port['device_id'])
             details['vm-name'] = vm.name if vm else port['device_id']
-        self._add_ip_mapping_details(context, port, details)
+        self._add_ip_mapping_details(context, port, kwargs['host'], details)
         self._add_network_details(context, port, details)
         if self._is_nat_enabled_on_ext_net(network):
             # PTG name is different
@@ -438,7 +438,7 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
                 'prefixlen':
                 netaddr.IPNetwork(snat_subnets[0]['cidr']).prefixlen}
 
-    def _add_ip_mapping_details(self, context, port, details):
+    def _add_ip_mapping_details(self, context, port, host, details):
         """Add information about IP mapping for DNAT/SNAT."""
         l3plugin = manager.NeutronManager.get_service_plugins().get(
             constants.L3_ROUTER_NAT)
@@ -492,7 +492,7 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
                              self._get_network_app_profile(network))})
             host_snat_ip_allocation = (
                 self._allocate_snat_ip_for_host_and_ext_net(
-                    context, details['host'], network))
+                    context, host, network))
             if host_snat_ip_allocation:
                 host_snat_ips.append(host_snat_ip_allocation)
 

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -1790,7 +1790,7 @@ class TestCiscoApicMechDriverHostSNAT(ApicML2IntegratedTestBase):
         sub = self.create_subnet(
             network_id=net['id'], cidr='10.0.0.0/24',
             ip_version=4, is_admin_context=True)
-        host_arg = {'binding:host_id': 'h1'}
+        host_arg = {'binding:host_id': 'h2'}
         with self.port(subnet=sub, tenant_id='anothertenant',
                        device_owner='compute:', device_id='someid',
                        arg_list=(portbindings.HOST_ID,), **host_arg) as p1:


### PR DESCRIPTION
We look at the binding-host of a port to decide the
host SNAT IP that should be returned in GBP details.
For a VM that is in the process of live migration,
the binding-host may still be the source host while
the RPC request comes from the destination host. In
this case we wrongly send the host SNAT IP of the
source host.
The fix is to use the host of the agent making the
RPC call to decide which host SNAT IP to report.

Signed-off-by: Amit Bose bose@noironetworks.com
