### PR TITLE
Make 'master' work with Liberty version of Neutron

### DIFF
--- a/.testr.conf
+++ b/.testr.conf
@@ -1,7 +1,9 @@
 [DEFAULT]
 test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
              OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-1} \
+             OS_LOG_CAPTURE=${OS_LOG_CAPTURE:-1} \
              OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-60} \
+             OS_DEBUG=True \
              ${PYTHON:-python} -m subunit.run discover -t ./ . $LISTOPT $IDOPTION
 test_id_option=--load-list $IDFILE
 test_list_option=--list

--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/apic_model.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/apic_model.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2014 Cisco Systems Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import sqlalchemy as sa
+from sqlalchemy import orm
+
+from neutron.db import api as db_api
+from neutron.db import model_base
+from neutron.db import models_v2
+from neutron.plugins.ml2 import models as models_ml2
+
+
+class RouterContract(model_base.BASEV2, models_v2.HasTenant):
+
+    """Contracts created on the APIC.
+
+    tenant_id represents the owner (APIC side) of the contract.
+    router_id is the UUID of the router (Neutron side) this contract is
+    referring to.
+    """
+
+    __tablename__ = 'cisco_ml2_apic_contracts'
+
+    # TODO(HenryG): this must be changed to String(36) for Mitaka
+    router_id = sa.Column(sa.String(64), sa.ForeignKey('routers.id'),
+                          primary_key=True)
+
+
+class HostLink(model_base.BASEV2):
+
+    """Connectivity of host links."""
+
+    __tablename__ = 'cisco_ml2_apic_host_links'
+
+    host = sa.Column(sa.String(255), nullable=False, primary_key=True)
+    ifname = sa.Column(sa.String(64), nullable=False, primary_key=True)
+    ifmac = sa.Column(sa.String(32), nullable=True)
+    swid = sa.Column(sa.String(32), nullable=False)
+    module = sa.Column(sa.String(32), nullable=False)
+    port = sa.Column(sa.String(32), nullable=False)
+
+
+class ApicName(model_base.BASEV2):
+    """Mapping of names created on the APIC."""
+
+    __tablename__ = 'cisco_ml2_apic_names'
+
+    neutron_id = sa.Column(sa.String(36), nullable=False, primary_key=True)
+    neutron_type = sa.Column(sa.String(32), nullable=False, primary_key=True)
+    apic_name = sa.Column(sa.String(255), nullable=False)
+
+
+class ApicDbModel(object):
+
+    """DB Model to manage all APIC DB interactions."""
+
+    def __init__(self):
+        self.session = db_api.get_session()
+
+    def get_contract_for_router(self, router_id):
+        """Returns the specified router's contract."""
+        return self.session.query(RouterContract).filter_by(
+            router_id=router_id).first()
+
+    def write_contract_for_router(self, tenant_id, router_id):
+        """Stores a new contract for the given tenant."""
+        contract = RouterContract(tenant_id=tenant_id,
+                                  router_id=router_id)
+        with self.session.begin(subtransactions=True):
+            self.session.add(contract)
+        return contract
+
+    def update_contract_for_router(self, tenant_id, router_id):
+        with self.session.begin(subtransactions=True):
+            contract = self.session.query(RouterContract).filter_by(
+                router_id=router_id).with_lockmode('update').first()
+            if contract:
+                contract.tenant_id = tenant_id
+                self.session.merge(contract)
+            else:
+                self.write_contract_for_router(tenant_id, router_id)
+
+    def delete_contract_for_router(self, router_id):
+        with self.session.begin(subtransactions=True):
+            try:
+                self.session.query(RouterContract).filter_by(
+                    router_id=router_id).delete()
+            except orm.exc.NoResultFound:
+                return
+
+    def add_hostlink(self, host, ifname, ifmac, swid, module, port):
+        link = HostLink(host=host, ifname=ifname, ifmac=ifmac,
+                        swid=swid, module=module, port=port)
+        with self.session.begin(subtransactions=True):
+            self.session.merge(link)
+
+    def get_hostlinks(self):
+        return self.session.query(HostLink).all()
+
+    def get_hostlink(self, host, ifname):
+        return self.session.query(HostLink).filter_by(
+            host=host, ifname=ifname).first()
+
+    def get_hostlinks_for_host(self, host):
+        return self.session.query(HostLink).filter_by(
+            host=host).all()
+
+    def get_hostlinks_for_host_switchport(self, host, swid, module, port):
+        return self.session.query(HostLink).filter_by(
+            host=host, swid=swid, module=module, port=port).all()
+
+    def get_hostlinks_for_switchport(self, swid, module, port):
+        return self.session.query(HostLink).filter_by(
+            swid=swid, module=module, port=port).all()
+
+    def delete_hostlink(self, host, ifname):
+        with self.session.begin(subtransactions=True):
+            try:
+                self.session.query(HostLink).filter_by(host=host,
+                                                       ifname=ifname).delete()
+            except orm.exc.NoResultFound:
+                return
+
+    def get_switches(self):
+        return self.session.query(HostLink.swid).distinct()
+
+    def get_modules_for_switch(self, swid):
+        return self.session.query(
+            HostLink.module).filter_by(swid=swid).distinct()
+
+    def get_ports_for_switch_module(self, swid, module):
+        return self.session.query(
+            HostLink.port).filter_by(swid=swid, module=module).distinct()
+
+    def get_switch_and_port_for_host(self, host):
+        return self.session.query(
+            HostLink.swid, HostLink.module, HostLink.port).filter_by(
+                host=host).distinct()
+
+    def get_tenant_network_vlan_for_host(self, host):
+        pb = models_ml2.PortBinding
+        po = models_v2.Port
+        ns = models_ml2.NetworkSegment
+        return self.session.query(
+            po.tenant_id, ns.network_id, ns.segmentation_id).filter(
+            po.id == pb.port_id).filter(pb.host == host).filter(
+                po.network_id == ns.network_id).distinct()
+
+    def add_apic_name(self, neutron_id, neutron_type, apic_name):
+        name = ApicName(neutron_id=neutron_id,
+                        neutron_type=neutron_type,
+                        apic_name=apic_name)
+        with self.session.begin(subtransactions=True):
+            self.session.add(name)
+
+    def update_apic_name(self, neutron_id, neutron_type, apic_name):
+        with self.session.begin(subtransactions=True):
+            name = self.session.query(ApicName).filter_by(
+                neutron_id=neutron_id,
+                neutron_type=neutron_type).with_lockmode('update').first()
+            if name:
+                name.apic_name = apic_name
+                self.session.merge(name)
+            else:
+                self.add_apic_name(neutron_id, neutron_type, apic_name)
+
+    def get_apic_names(self):
+        return self.session.query(ApicName).all()
+
+    def get_apic_name(self, neutron_id, neutron_type):
+        return self.session.query(ApicName.apic_name).filter_by(
+            neutron_id=neutron_id, neutron_type=neutron_type).first()
+
+    def delete_apic_name(self, neutron_id):
+        with self.session.begin(subtransactions=True):
+            try:
+                self.session.query(ApicName).filter_by(
+                    neutron_id=neutron_id).delete()
+            except orm.exc.NoResultFound:
+                return

--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/apic_sync.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/apic_sync.py
@@ -16,10 +16,10 @@
 from neutron.common import constants as n_constants
 from neutron import context
 from neutron import manager
-from neutron.openstack.common import loopingcall
 from neutron.plugins.ml2 import db as l2_db
 from neutron.plugins.ml2 import driver_context
 from oslo_log import log as logging
+from oslo_service import loopingcall
 
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import constants
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import exceptions as aexc

--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/apic_topology.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/apic_topology.py
@@ -21,6 +21,8 @@ import eventlet
 eventlet.monkey_patch()
 from oslo_config import cfg
 from oslo_log import log as logging
+from oslo_service import periodic_task
+from oslo_service import service as svc
 
 from neutron.agent.common import config
 from neutron.agent.linux import ip_lib
@@ -31,8 +33,6 @@ from neutron.common import utils as neutron_utils
 from neutron.db import agents_db
 from neutron.i18n import _LE, _LI
 from neutron import manager
-from neutron.openstack.common import periodic_task
-from neutron.openstack.common import service as svc
 from neutron import service
 
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import (mechanism_apic as

--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -33,7 +33,6 @@ from neutron.plugins.common import constants
 from neutron.plugins.ml2 import db as ml2_db
 from neutron.plugins.ml2 import driver_api as api
 from neutron.plugins.ml2 import driver_context
-from neutron.plugins.ml2.drivers.cisco.apic import apic_model
 from neutron.plugins.ml2.drivers import mech_agent
 from neutron.plugins.ml2.drivers import type_vlan  # noqa
 from neutron.plugins.ml2 import models
@@ -43,6 +42,7 @@ from oslo_concurrency import lockutils
 from oslo_config import cfg
 from oslo_log import log as logging
 
+from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import apic_model
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import apic_sync
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import attestation
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import config
@@ -143,7 +143,9 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
             apic_config.scope_names = False
         APICMechanismDriver.apic_manager = apic_manager.APICManager(
             apic_model.ApicDbModel(), logging, network_config, apic_config,
-            keyclient_param, keystone_authtoken, apic_system_id)
+            keyclient_param, keystone_authtoken, apic_system_id,
+            default_apic_model=('apic_ml2.neutron.plugins.ml2.drivers.'
+                                'cisco.apic.apic_model'))
         return APICMechanismDriver.apic_manager
 
     @staticmethod
@@ -306,7 +308,7 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
     def get_gbp_details(self, context, **kwargs):
         core_plugin = manager.NeutronManager.get_plugin()
         port_id = core_plugin._device_to_port_id(
-            kwargs['device'])
+            context, kwargs['device'])
         port_context = core_plugin.get_bound_port_context(
             context, port_id, kwargs['host'])
         if not port_context:

--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/rpc.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/rpc.py
@@ -26,9 +26,10 @@ from neutron.db import api as db_api
 from neutron.extensions import providernet as api
 from neutron import manager
 from neutron.plugins.common import constants
-from neutron.plugins.ml2.drivers.cisco.apic import apic_model
 from neutron.plugins.ml2.drivers import type_vlan  # noqa
 from neutron.plugins.ml2 import models
+
+from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import apic_model
 
 TOPIC_APIC_SERVICE = 'apic-service'
 

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_common.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_common.py
@@ -23,6 +23,8 @@ from neutron.tests import base
 from oslo_config import cfg
 import webob
 
+from apicapi.apic_mapper import ApicName
+
 OK = requests.codes.ok
 
 APIC_HOSTS = ['fake.controller.local']
@@ -123,7 +125,7 @@ class ControllerMixin(object):
             return "NAT-vrf-%s" % (net_name or APIC_NETWORK)
         if self.driver.single_tenant_mode and self.driver.per_tenant_context:
             return APIC_TENANT
-        return 'shared'
+        return ApicName('shared')
 
     def _router_tenant(self):
         if self.driver.single_tenant_mode:

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -773,8 +773,9 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
 
     def test_initialize(self):
         mgr = self.driver.apic_manager
-        mgr.ensure_infra_created_on_apic.assert_called_once()
-        mgr.ensure_bgp_pod_policy_created_on_apic.assert_called_once()
+        self.assertEqual(1, mgr.ensure_infra_created_on_apic.call_count)
+        self.assertEqual(
+            1, mgr.ensure_bgp_pod_policy_created_on_apic.call_count)
 
     def test_update_port_postcommit(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,
@@ -951,7 +952,6 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         mgr.get_router_contract.assert_called_once_with(
             self._scoped_name(port_ctx.current['device_id']),
             owner=self._tenant(vrf=True))
-        mgr.ensure_context_enforced.assert_called_once()
 
         expected_calls = [
             mock.call("Shd-%s" % self._scoped_name(mocked.APIC_NETWORK_PRE),
@@ -1000,6 +1000,8 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         self._test_update_pre_gw_port_postcommit('admin_tenant')
 
     def test_update_pre_no_nat_gw_port_postcommit(self):
+        self.external_network_dict[mocked.APIC_NETWORK_PRE + '-name'][
+            'enable_nat'] = 'False'
         net_ctx = self._get_network_context(mocked.APIC_TENANT,
                                             mocked.APIC_NETWORK_PRE,
                                             TEST_SEGMENT1, external=True)
@@ -1020,7 +1022,6 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         mgr.get_router_contract.assert_called_once_with(
             self._scoped_name(port_ctx.current['device_id']),
             owner=self._tenant(vrf=True))
-        mgr.ensure_context_enforced.assert_called_once()
 
         self.assertFalse(mgr.ensure_external_routed_network_created.called)
         self.assertFalse(mgr.ensure_external_epg_created.called)
@@ -1164,17 +1165,6 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         mgr.delete_external_routed_network.assert_called_once_with(
             "Shd-%s" % self._scoped_name(mocked.APIC_NETWORK_PRE),
             owner=self._tenant())
-
-    def test_update_gw_port_postcommit_fail_contract_create(self):
-        net_ctx = self._get_network_context(mocked.APIC_TENANT,
-                                            mocked.APIC_NETWORK,
-                                            TEST_SEGMENT1, external=True)
-        port_ctx = self._get_port_context(mocked.APIC_TENANT,
-                                          mocked.APIC_NETWORK,
-                                          'vm1', net_ctx, HOST_ID1, gw=True)
-        mgr = self.driver.apic_manager
-        self.driver.update_port_postcommit(port_ctx)
-        mgr.ensure_external_routed_network_deleted.assert_called_once()
 
     def test_create_network_postcommit(self):
         ctx = self._get_network_context(mocked.APIC_TENANT,
@@ -1366,8 +1356,8 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         mgr = self.driver.apic_manager
         self.driver.delete_network_postcommit(ctx)
 
-        mgr.delete_bd_on_apic.assert_called_once()
-        mgr.delete_epg_for_network.assert_called_once()
+        self.assertEqual(1, mgr.delete_bd_on_apic.call_count)
+        self.assertEqual(1, mgr.delete_epg_for_network.call_count)
 
         mgr.delete_external_routed_network.assert_called_once_with(
             self._scoped_name(mocked.APIC_NETWORK), owner=self._tenant())
@@ -1394,8 +1384,8 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
             'vrf_tenant': 'bar_tenant'}
         self.driver.delete_network_postcommit(ctx)
 
-        mgr.delete_bd_on_apic.assert_called_once()
-        mgr.delete_epg_for_network.assert_called_once()
+        self.assertEqual(1, mgr.delete_bd_on_apic.call_count)
+        self.assertEqual(1, mgr.delete_epg_for_network.call_count)
 
         self.assertFalse(mgr.delete_external_routed_network.called)
 

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_sync.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_sync.py
@@ -23,7 +23,7 @@ from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import apic_sync
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import constants as acst
 from neutron.tests import base
 
-LOOPING_CALL = 'neutron.openstack.common.loopingcall.FixedIntervalLoopingCall'
+LOOPING_CALL = 'oslo_service.loopingcall.FixedIntervalLoopingCall'
 GET_PLUGIN = 'neutron.manager.NeutronManager.get_plugin'
 GET_ADMIN_CONTEXT = 'neutron.context.get_admin_context'
 L2_DB = 'neutron.plugins.ml2.db.get_locked_port_and_binding'

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_topology_agent.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_topology_agent.py
@@ -29,7 +29,7 @@ NOTIFIER = ('apic_ml2.neutron.plugins.ml2.drivers.cisco.apic.'
             'rpc.ApicTopologyServiceNotifierApi')
 RPC_CONNECTION = 'neutron.common.rpc.Connection'
 AGENTS_DB = 'neutron.db.agents_db'
-PERIODIC_TASK = 'neutron.openstack.common.periodic_task'
+PERIODIC_TASK = 'oslo_service.periodic_task'
 DEV_EXISTS = 'neutron.agent.linux.ip_lib.device_exists'
 IP_DEVICE = 'neutron.agent.linux.ip_lib.IPDevice'
 EXECUTE = 'neutron.agent.linux.utils.execute'

--- a/apic_ml2/neutron/tests/unit/services/l3_router/test_l3_apic_plugin.py
+++ b/apic_ml2/neutron/tests/unit/services/l3_router/test_l3_apic_plugin.py
@@ -67,7 +67,7 @@ class TestCiscoApicL3Plugin(testlib_api.SqlTestCase,
                             mocked.ConfigMixin):
     def setUp(self):
         super(TestCiscoApicL3Plugin, self).setUp()
-        mock.patch('neutron.plugins.ml2.drivers.cisco.apic.'
+        mock.patch('apic_ml2.neutron.plugins.ml2.drivers.cisco.apic.'
                    'apic_model.ApicDbModel').start()
         mocked.ControllerMixin.set_up_mocks(self)
         mocked.ConfigMixin.set_up_mocks(self)
@@ -178,7 +178,7 @@ class TestCiscoApicL3Plugin(testlib_api.SqlTestCase,
         mgr = self.plugin.manager
         self.plugin.remove_router_interface(self.context, ROUTER,
                                             interface_info)
-        mgr.delete_contract_for_epg.assert_called_once()
+        self.assertEqual(1, mgr.remove_router_interface.call_count)
 
     def test_add_router_interface_subnet(self):
         self._test_add_router_interface(self.interface_info['subnet'])

--- a/debian/changelog.in
+++ b/debian/changelog.in
@@ -1,5 +1,11 @@
 neutron-ml2-driver-apic (@VERSION@-@REVISION@) trusty; urgency=low
 
+  * Update to Liberty
+
+ -- Amit Bose <bose@noironetworks.com>  Mon, 11 Jan 2016 14:42:08 -0700
+
+neutron-ml2-driver-apic (2015.1.0-1) trusty; urgency=low
+
   * Update to Kilo
 
  -- Amit Bose <bose@noironetworks.com>  Tue, 25 Aug 2015 15:13:46 -0700

--- a/rpm/neutron-ml2-driver-apic.spec.in
+++ b/rpm/neutron-ml2-driver-apic.spec.in
@@ -1,4 +1,4 @@
-%global release_name kilo
+%global release_name liberty
 %define host_agent neutron-cisco-apic-host-agent.service
 %define service_agent neutron-cisco-apic-service-agent.service
 %define version_py @VERSION_PY@
@@ -14,8 +14,8 @@ BuildArch:	noarch
 BuildRequires:	python2-devel
 BuildRequires:	python-pbr
 BuildRequires:	python-setuptools
-Requires:	openstack-neutron-ml2 >= 2015.1
-Requires:	openstack-neutron-ml2 < 2015.2
+Requires:	openstack-neutron-ml2 >= 2015.2
+Requires:	openstack-neutron-ml2 < 2015.3
 Requires:	lldpad
 Requires:	apicapi
 Requires:	python-oslo-concurrency
@@ -95,6 +95,8 @@ apic-ml2-db-manage --config-file /etc/neutron/neutron.conf upgrade head
 %{_sysconfdir}/neutron/rootwrap.d/cisco-apic.filters
 
 %changelog
+* Mon Jan 11 2016 Amit Bose <bose@noironetworks.com> - 2015.2.0-1
+- Update to Liberty
 * Tue Aug 25 2015 Amit Bose <bose@noironetworks.com> - 2015.1.0-1
 - Update to Kilo
 * Mon May 18 2015 Amit Bose <bose@noironetworks.com> - 1.0.0-1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,21 +2,26 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
--e git://github.com/openstack/neutron.git@stable/kilo#egg=neutron
+-e git://github.com/openstack/neutron.git@stable/liberty#egg=neutron
 hacking<0.11,>=0.10.0
 
-cliff<1.11.0,>=1.10.0 # Apache-2.0
+cliff>=1.14.0 # Apache-2.0
 coverage>=3.6
-fixtures<1.3.0,>=0.3.14
-mock<1.1.0,>=1.0
+fixtures>=1.3.1
+mock>=1.2
 python-subunit>=0.0.18
 requests-mock>=0.6.0 # Apache-2.0
 sphinx!=1.2.0,!=1.3b1,<1.3,>=1.1.2
-oslosphinx<2.6.0,>=2.5.0 # Apache-2.0
+oslosphinx>=2.5.0 # Apache-2.0
 testrepository>=0.0.18
-testtools!=1.2.0,>=0.9.36
+testtools>=1.4.0
+testresources>=0.2.4
 testscenarios>=0.4
 WebTest>=2.0
-oslotest<1.6.0,>=1.5.1 # Apache-2.0
-tempest-lib<0.5.0,>=0.4.0
+oslotest>=1.10.0 # Apache-2.0
+os-testr>=0.1.0
+tempest-lib>=0.8.0
+ddt>=0.7.0
+pylint==1.4.4 # GNU GPL v2
 pyOpenSSL>=0.13.0,<=0.15.1
+reno>=0.1.1 # Apache2


### PR DESCRIPTION
This change is based on Sumit's legwork for making
apic ML2 driver work with Liberty. Notable changes:
- Since apic_model.py is no longer present in neutron,
  I've copied the file from repository
  github.com/openstack/networking-cisco at commit
  2e8148ae0f3f3b63781c2a9c857b21e2fc33caf1
- Unit-test code had a few changes because of newer
  version of mock, such as no support for
  assert_called_once(). Also, it looks like some of the
  tests which used assert_called_once() were broken and
  the failure was being masked for some reason.

Signed-off-by: Amit Bose bose@noironetworks.com
