### PR TITLE
Add support for allowed-address-pairs

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -26,7 +26,9 @@ from neutron.common import exceptions as n_exc
 from neutron.common import rpc as n_rpc
 from neutron.common import topics
 from neutron import context as nctx
+from neutron.db import allowedaddresspairs_db as n_addr_pair_db
 from neutron.db import db_base_plugin_v2 as n_db
+from neutron.db import models_v2
 from neutron.extensions import portbindings
 from neutron import manager
 from neutron.plugins.common import constants
@@ -42,6 +44,7 @@ from oslo_concurrency import lockutils
 from oslo_config import cfg
 from oslo_log import log as logging
 
+from apic_ml2.neutron.db import port_ha_ipaddress_binding as ha_ip_db
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import apic_model
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import apic_sync
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import attestation
@@ -119,7 +122,8 @@ class NameMapper(object):
         return name_wrapper
 
 
-class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
+class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
+                          ha_ip_db.HAIPOwnerDbMixin):
 
     apic_manager = None
 
@@ -184,6 +188,7 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
         self.vif_type = portbindings.VIF_TYPE_OVS
         super(APICMechanismDriver, self).__init__(
             ofcst.AGENT_TYPE_OPFLEX_OVS)
+        ha_ip_db.HAIPOwnerDbMixin.__init__(self)
 
     def try_to_bind_segment_for_agent(self, context, segment, agent):
         if self.check_segment_for_agent(segment, agent):
@@ -348,8 +353,10 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
         if port['device_owner'].startswith('compute:') and port['device_id']:
             vm = nova_client.NovaClient().get_server(port['device_id'])
             details['vm-name'] = vm.name if vm else port['device_id']
-        self._add_ip_mapping_details(context, port, kwargs['host'], details)
-        self._add_network_details(context, port, details)
+        owned_addr = self.ha_ip_handler.get_ha_ipaddresses_for_port(port['id'])
+        self._add_ip_mapping_details(context, port, kwargs['host'], owned_addr,
+                                     details)
+        self._add_network_details(context, port, owned_addr, details)
         if self._is_nat_enabled_on_ext_net(network):
             # PTG name is different
             details['endpoint_group_name'] = self._get_ext_epg_for_ext_net(
@@ -440,11 +447,26 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
                 'prefixlen':
                 netaddr.IPNetwork(snat_subnets[0]['cidr']).prefixlen}
 
-    def _add_ip_mapping_details(self, context, port, host, details):
+    def _add_ip_mapping_details(self, context, port, host, owned_addr,
+                                details):
         """Add information about IP mapping for DNAT/SNAT."""
         l3plugin = manager.NeutronManager.get_service_plugins().get(
             constants.L3_ROUTER_NAT)
         core_plugin = context._plugin
+
+        fips_filter = [port['id']]
+        if owned_addr:
+            # If another port has a fixed IP that is same as an owned address,
+            # then steal that port's floating IP
+            other_ports = core_plugin.get_ports(
+                context,
+                filters={
+                    'network_id': [port['network_id']],
+                    'fixed_ips': {'ip_address': owned_addr}})
+            fips_filter.extend([p['id'] for p in other_ports])
+        fips = l3plugin.get_floatingips(
+            context,
+            filters={'port_id': fips_filter})
 
         ext_nets = core_plugin.get_networks(
             context,
@@ -453,8 +475,6 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
                     if self._is_nat_enabled_on_ext_net(n)}
         fip_ext_nets = set()
 
-        fips = l3plugin.get_floatingips(context,
-                                        filters={'port_id': [port['id']]})
         for f in fips:
             net = ext_nets.get(f['floating_network_id'])
             if not net:
@@ -515,10 +535,15 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
             context, [x['device_id'] for x in router_gw_ports])
         return bool(port_sn & router_sn)
 
-    def _add_network_details(self, context, port, details):
+    def _add_network_details(self, context, port, owned_addr, details):
         details['allowed_address_pairs'] = port['allowed_address_pairs']
         details['enable_dhcp_optimization'] = self.enable_dhcp_opt
         details['enable_metadata_optimization'] = self.enable_metadata_opt
+        # mark owned addresses from allowed-address pairs as 'active'
+        owned_addr = set(owned_addr)
+        for allowed in details['allowed_address_pairs']:
+            if allowed['ip_address'] in owned_addr:
+                allowed['active'] = True
         details['subnets'] = context._plugin.get_subnets(
             context,
             filters={'id': [ip['subnet_id'] for ip in port['fixed_ips']]})
@@ -552,6 +577,15 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
                         {'destination': dhcp.METADATA_DEFAULT_CIDR,
                          'nexthop': dhcp_ips[0]})
             subnet['dhcp_server_ips'] = dhcp_ips
+
+    # RPC Method
+    def ip_address_owner_update(self, context, **kwargs):
+        if not kwargs.get('ip_owner_info'):
+            return
+        ports_to_update = self.update_ip_owner(kwargs['ip_owner_info'])
+        for p in ports_to_update:
+            LOG.debug("Ownership update for port %s", p)
+            self.notify_port_update(p)
 
     def sync_init(f):
         def inner(inst, *args, **kwargs):
@@ -965,6 +999,26 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase):
         except n_exc.PortNotFound:
             # Notification not needed
             pass
+
+    def notify_port_update_for_fip(self, port_id, context=None):
+        context = context or nctx.get_admin_context()
+        core_plugin = manager.NeutronManager.get_plugin()
+        try:
+            port = core_plugin.get_port(context, port_id)
+        except n_exc.PortNotFound:
+            return
+        ports_to_notify = [port_id]
+        fixed_ips = [x['ip_address'] for x in port['fixed_ips']]
+        if fixed_ips:
+            addr_pair = (
+                context.session.query(n_addr_pair_db.AllowedAddressPair)
+                .join(models_v2.Port)
+                .filter(models_v2.Port.network_id == port['network_id'])
+                .filter(n_addr_pair_db.AllowedAddressPair.ip_address.in_(
+                    fixed_ips)).all())
+            ports_to_notify.extend([x['port_id'] for x in addr_pair])
+        for p in sorted(ports_to_notify):
+            self.notify_port_update(p, context)
 
     def notify_subnet_update(self, subnet, context=None):
         context = context or nctx.get_admin_context()

--- a/apic_ml2/neutron/services/l3_router/l3_apic.py
+++ b/apic_ml2/neutron/services/l3_router/l3_apic.py
@@ -315,7 +315,7 @@ class ApicL3ServicePlugin(db_base_plugin_v2.NeutronDbPluginV2,
     def _notify_port_update(self, port_id):
         l2 = mechanism_apic.APICMechanismDriver.get_driver_instance()
         if l2 and port_id:
-            l2.notify_port_update(port_id)
+            l2.notify_port_update_for_fip(port_id)
 
     def _update_floatingip_status(self, context, fip_id):
         status = q_const.FLOATINGIP_STATUS_DOWN

--- a/apic_ml2/neutron/tests/unit/services/l3_router/test_l3_apic_plugin.py
+++ b/apic_ml2/neutron/tests/unit/services/l3_router/test_l3_apic_plugin.py
@@ -76,7 +76,7 @@ class TestCiscoApicL3Plugin(testlib_api.SqlTestCase,
         self.ml2_driver = mock.Mock()
         md.APICMechanismDriver.get_driver_instance = mock.Mock(
             return_value=self.ml2_driver)
-        md.APICMechanismDriver.notify_port_update = mock.Mock()
+        md.APICMechanismDriver.notify_port_update_for_fip = mock.Mock()
         self.context = context.get_admin_context()
         self.context.tenant_id = TENANT
         self.interface_info = {'subnet': {'subnet_id': SUBNET},
@@ -210,30 +210,33 @@ class TestCiscoApicL3Plugin(testlib_api.SqlTestCase,
         # create floating-ip with mapped port
         self.plugin.create_floatingip(self.context,
                                       {'floatingip': self.floatingip})
-        self.ml2_driver.notify_port_update.assert_called_once_with(PORT)
+        self.ml2_driver.notify_port_update_for_fip.assert_called_once_with(
+            PORT)
 
     def test_floatingip_port_notify_on_reassociate(self):
         # associate with different port
         new_fip = {'port_id': 'port-another'}
-        self.ml2_driver.notify_port_update.reset_mock()
+        self.ml2_driver.notify_port_update_for_fip.reset_mock()
         self.plugin.update_floatingip(self.context, FLOATINGIP,
                                       {'floatingip': new_fip})
         self._check_call_list(
             [mock.call(PORT), mock.call('port-another')],
-            self.ml2_driver.notify_port_update.call_args_list)
+            self.ml2_driver.notify_port_update_for_fip.call_args_list)
 
     def test_floatingip_port_notify_on_disassociate(self):
         # dissociate mapped port
-        self.ml2_driver.notify_port_update.reset_mock()
+        self.ml2_driver.notify_port_update_for_fip.reset_mock()
         self.plugin.update_floatingip(self.context, FLOATINGIP,
                                       {'floatingip': {}})
-        self.ml2_driver.notify_port_update.assert_called_once_with(PORT)
+        self.ml2_driver.notify_port_update_for_fip.assert_called_once_with(
+            PORT)
 
     def test_floatingip_port_notify_on_delete(self):
         # delete
-        self.ml2_driver.notify_port_update.reset_mock()
+        self.ml2_driver.notify_port_update_for_fip.reset_mock()
         self.plugin.delete_floatingip(self.context, FLOATINGIP)
-        self.ml2_driver.notify_port_update.assert_called_once_with(PORT)
+        self.ml2_driver.notify_port_update_for_fip.assert_called_once_with(
+            PORT)
 
     def test_floatingip_status(self):
         # create floating-ip with mapped port


### PR DESCRIPTION
Changes include -
- Modify DB tables in response Respond to RPC
  for ip-ownership-update.
- Set all allowed-addresses that are currently
  owned as 'active' in get_gbp_details().
- "Steal" floating IP addresses of other ports
  in the same network whose fixed-ip is the same
  as an owned allowed-address.
- Ensure that floating-IP updates result in
  update notifications for other ports that have
  the mapped-ip as an allowed-address.

Signed-off-by: Amit Bose bose@noironetworks.com
