### PR TITLE
Remove L2 plugin parent class.

### DIFF
--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -110,7 +110,6 @@ class ApicML2IntegratedTestBase(test_plugin.NeutronDbPluginV2TestCase,
             PLUGIN_NAME, service_plugins=service_plugins)
         ext_mgr = extensions.PluginAwareExtensionManager.get_instance()
         self.ext_api = test_extensions.setup_extensions_middleware(ext_mgr)
-        self.plugin = manager.NeutronManager.get_plugin()
         self.plugin.remove_networks_from_down_agents = mock.Mock()
         self.plugin.is_agent_down = mock.Mock(return_value=False)
         self.driver = self.plugin.mechanism_manager.mech_drivers[

--- a/apic_ml2/neutron/tests/unit/services/l3_router/test_l3_apic_plugin.py
+++ b/apic_ml2/neutron/tests/unit/services/l3_router/test_l3_apic_plugin.py
@@ -20,6 +20,7 @@ from neutron.common import constants as q_const
 from neutron.common import exceptions as n_exc
 from neutron import context
 
+import apicapi.apic_mapper  # noqa
 sys.modules["apicapi"] = mock.Mock()
 
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import (
@@ -109,12 +110,13 @@ class TestCiscoApicL3Plugin(testlib_api.SqlTestCase,
                           'tenant_id': TENANT})
         self.plugin.manager.apic.transaction = self.fake_transaction
 
-        self.plugin.get_subnet = mock.Mock(return_value=self.subnet)
-        self.plugin.get_network = mock.Mock(return_value=self.network)
-        self.plugin.get_port = mock.Mock(return_value=self.port)
-        self.plugin.get_ports = mock.Mock(return_value=[self.port])
         self.plugin._aci_mech_driver = mock.Mock()
-        self.plugin.ml2_plugin = mock.Mock()
+        self.plugin._ml2_plugin = mock.Mock()
+        self.plugin.ml2_plugin.get_subnet = mock.Mock(return_value=self.subnet)
+        self.plugin.ml2_plugin.get_network = mock.Mock(
+            return_value=self.network)
+        self.plugin.ml2_plugin.get_port = mock.Mock(return_value=self.port)
+        self.plugin.ml2_plugin.get_ports = mock.Mock(return_value=[self.port])
         self.plugin.get_floatingip = mock.Mock(return_value=self.floatingip)
         self.plugin.update_floatingip_status = mock.Mock()
 


### PR DESCRIPTION
This removes the NeutronDbPluginV2 class from the
inheritance hierarchy. It also adds a weak reference
to the ML2 core plugin, and uses that reference to
call the methods that were previously inherited
from the NeutronDbPluginV2 class. It also addresses
some problems with the l3 plugin unit tests (still
can't run them individually using tox, but they will
run when .tox/py27/bin/activate is sourced and
python -m testtools.run is used).

Signed-off-by: Thomas Bachman tbachman@yahoo.com
