### PR TITLE
Remove L2 plugin parent class.

### DIFF
--- a/apic_ml2/neutron/services/l3_router/l3_apic.py
+++ b/apic_ml2/neutron/services/l3_router/l3_apic.py
@@ -16,12 +16,10 @@
 from apicapi import apic_mapper
 from neutron.common import constants as q_const
 from neutron.common import exceptions as n_exc
-from neutron.db import db_base_plugin_v2
+from neutron.db import common_db_mixin
 from neutron.db import extraroute_db
 from neutron.db import l3_db
-from neutron.db import l3_dvr_db
 from neutron.extensions import l3
-from neutron import manager
 from neutron.plugins.common import constants
 from oslo_log import log as logging
 from oslo_utils import excutils
@@ -36,8 +34,7 @@ class InterTenantRouterInterfaceNotAllowedOnPerTenantContext(n_exc.BadRequest):
                 "another tenant when per_tenant_context is enabled.")
 
 
-class ApicL3ServicePlugin(db_base_plugin_v2.NeutronDbPluginV2,
-                          l3_dvr_db.L3_NAT_with_dvr_db_mixin,
+class ApicL3ServicePlugin(common_db_mixin.CommonDbMixin,
                           extraroute_db.ExtraRoute_db_mixin):
     supported_extension_aliases = ["router", "ext-gw-mode", "extraroute"]
 
@@ -49,15 +46,12 @@ class ApicL3ServicePlugin(db_base_plugin_v2.NeutronDbPluginV2,
         self.manager.ensure_infra_created_on_apic()
         self.manager.ensure_bgp_pod_policy_created_on_apic()
         self._aci_mech_driver = None
-        self.ml2_plugin = None
 
     @property
     def aci_mech_driver(self):
-        if not self.ml2_plugin:
-            self.ml2_plugin = manager.NeutronManager.get_plugin()
         if not self._aci_mech_driver:
             self._aci_mech_driver = (
-                self.ml2_plugin.mechanism_manager.mech_drivers[
+                self._core_plugin.mechanism_manager.mech_drivers[
                     'cisco_apic_ml2'].obj)
         return self._aci_mech_driver
 
@@ -77,7 +71,8 @@ class ApicL3ServicePlugin(db_base_plugin_v2.NeutronDbPluginV2,
         filters = {'device_id': [router_id],
                    'device_owner': [q_const.DEVICE_OWNER_ROUTER_INTF],
                    'fixed_ips': {'subnet_id': [subnet_id]}}
-        ports = self.get_ports(context.elevated(), filters=filters)
+        ports = self._core_plugin.get_ports(context.elevated(),
+                                            filters=filters)
         return ports[0]['id']
 
     def _update_router_gw_info(self, context, router_id, info, router=None):
@@ -87,8 +82,9 @@ class ApicL3ServicePlugin(db_base_plugin_v2.NeutronDbPluginV2,
             filters = {'device_id': [router_id],
                        'device_owner': [q_const.DEVICE_OWNER_ROUTER_GW],
                        'network_id': [info['network_id']]}
-            ports = self.get_ports(context.elevated(), filters=filters)
-            manager.NeutronManager.get_plugin().update_port_status(
+            ports = self._core_plugin.get_ports(context.elevated(),
+                                                filters=filters)
+            self._core_plugin.update_port_status(
                 context, ports[0]['id'], q_const.PORT_STATUS_ACTIVE)
 
     @staticmethod
@@ -118,16 +114,18 @@ class ApicL3ServicePlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
         # Add router interface
         if 'subnet_id' in interface_info:
-            subnet = self.get_subnet(context, interface_info['subnet_id'])
+            subnet = self._core_plugin.get_subnet(context,
+                                                  interface_info['subnet_id'])
             network_id = subnet['network_id']
             port_id = self._get_port_id_for_router_interface(
                 context, router_id, interface_info['subnet_id'])
         else:
-            port = self.get_port(context, interface_info['port_id'])
+            port = self._core_plugin.get_port(context,
+                                              interface_info['port_id'])
             network_id = port['network_id']
             port_id = interface_info['port_id']
 
-        network = self.get_network(context, network_id)
+        network = self._core_plugin.get_network(context, network_id)
         tenant_id = network['tenant_id']
         if (tenant_id != router['tenant_id'] and
                 self.aci_mech_driver.per_tenant_context and
@@ -145,22 +143,24 @@ class ApicL3ServicePlugin(db_base_plugin_v2.NeutronDbPluginV2,
             arouter_id, anetwork_id,
             app_profile_name=self.aci_mech_driver._get_network_app_profile(
                 network))
-        self.ml2_plugin.update_port_status(context, port_id,
-                                           q_const.PORT_STATUS_ACTIVE)
+        self._core_plugin.update_port_status(context, port_id,
+                                             q_const.PORT_STATUS_ACTIVE)
 
     def remove_router_interface_precommit(self, context, router_id,
                                           interface_info):
         if 'subnet_id' in interface_info:
-            subnet = self.get_subnet(context, interface_info['subnet_id'])
+            subnet = self._core_plugin.get_subnet(context,
+                                                  interface_info['subnet_id'])
             network_id = subnet['network_id']
             port_id = self._get_port_id_for_router_interface(
                 context, router_id, interface_info['subnet_id'])
         else:
-            port = self.get_port(context, interface_info['port_id'])
+            port = self._core_plugin.get_port(context,
+                                              interface_info['port_id'])
             network_id = port['network_id']
             port_id = interface_info['port_id']
 
-        network = self.get_network(context, network_id)
+        network = self._core_plugin.get_network(context, network_id)
         tenant_id = network['tenant_id']
 
         router = self.get_router(context, router_id)
@@ -174,8 +174,8 @@ class ApicL3ServicePlugin(db_base_plugin_v2.NeutronDbPluginV2,
             arouter_id, anetwork_id,
             app_profile_name=self.aci_mech_driver._get_network_app_profile(
                 network))
-        self.ml2_plugin.update_port_status(context, port_id,
-                                           q_const.PORT_STATUS_DOWN)
+        self._core_plugin.update_port_status(context, port_id,
+                                             q_const.PORT_STATUS_DOWN)
 
     def delete_router_precommit(self, context, router_id):
         context._plugin = self

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -110,7 +110,6 @@ class ApicML2IntegratedTestBase(test_plugin.NeutronDbPluginV2TestCase,
             PLUGIN_NAME, service_plugins=service_plugins)
         ext_mgr = extensions.PluginAwareExtensionManager.get_instance()
         self.ext_api = test_extensions.setup_extensions_middleware(ext_mgr)
-        self.plugin = manager.NeutronManager.get_plugin()
         self.plugin.remove_networks_from_down_agents = mock.Mock()
         self.plugin.is_agent_down = mock.Mock(return_value=False)
         self.driver = self.plugin.mechanism_manager.mech_drivers[

--- a/apic_ml2/neutron/tests/unit/services/l3_router/test_l3_apic_plugin.py
+++ b/apic_ml2/neutron/tests/unit/services/l3_router/test_l3_apic_plugin.py
@@ -19,7 +19,9 @@ import mock
 from neutron.common import constants as q_const
 from neutron.common import exceptions as n_exc
 from neutron import context
+from neutron import manager
 
+import apicapi.apic_mapper  # noqa
 sys.modules["apicapi"] = mock.Mock()
 
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import (
@@ -109,30 +111,34 @@ class TestCiscoApicL3Plugin(testlib_api.SqlTestCase,
                           'tenant_id': TENANT})
         self.plugin.manager.apic.transaction = self.fake_transaction
 
-        self.plugin.get_subnet = mock.Mock(return_value=self.subnet)
-        self.plugin.get_network = mock.Mock(return_value=self.network)
-        self.plugin.get_port = mock.Mock(return_value=self.port)
-        self.plugin.get_ports = mock.Mock(return_value=[self.port])
         self.plugin._aci_mech_driver = mock.Mock()
-        self.plugin.ml2_plugin = mock.Mock()
+        manager.NeutronManager.get_plugin = mock.Mock()
+        manager.NeutronManager.get_plugin.get_subnet = mock.Mock(
+            return_value=self.subnet)
+        manager.NeutronManager.get_plugin.get_network = mock.Mock(
+            return_value=self.network)
+        manager.NeutronManager.get_plugin.get_port = mock.Mock(
+            return_value=self.port)
+        manager.NeutronManager.get_plugin.get_ports = mock.Mock(
+            return_value=[self.port])
         self.plugin.get_floatingip = mock.Mock(return_value=self.floatingip)
         self.plugin.update_floatingip_status = mock.Mock()
 
-        mock.patch('neutron.db.l3_dvr_db.L3_NAT_with_dvr_db_mixin.'
+        mock.patch('neutron.db.l3_db.L3_NAT_db_mixin.'
                    '_core_plugin').start()
-        mock.patch('neutron.db.l3_dvr_db.L3_NAT_with_dvr_db_mixin.'
+        mock.patch('neutron.db.l3_db.L3_NAT_db_mixin.'
                    'add_router_interface').start()
-        mock.patch('neutron.db.l3_dvr_db.L3_NAT_with_dvr_db_mixin.'
+        mock.patch('neutron.db.l3_db.L3_NAT_db_mixin.'
                    'remove_router_interface').start()
         mock.patch(
             'neutron.manager.NeutronManager.get_service_plugins').start()
-        mock.patch('neutron.db.l3_dvr_db.L3_NAT_with_dvr_db_mixin.'
+        mock.patch('neutron.db.l3_db.L3_NAT_db_mixin.'
                    'update_floatingip',
                    new=mock.Mock(return_value=self.floatingip)).start()
-        mock.patch('neutron.db.l3_dvr_db.L3_NAT_with_dvr_db_mixin.'
+        mock.patch('neutron.db.l3_db.L3_NAT_db_mixin.'
                    'create_floatingip',
                    new=mock.Mock(return_value=self.floatingip)).start()
-        mock.patch('neutron.db.l3_dvr_db.L3_NAT_with_dvr_db_mixin.'
+        mock.patch('neutron.db.l3_db.L3_NAT_db_mixin.'
                    'delete_floatingip').start()
 
         def _get_router_aci_tenant(router):


### PR DESCRIPTION
This removes the NeutronDbPluginV2 class from the
inheritance hierarchy, and changes from the DVR
parent class to the non-DVR calss. It replaces
references to the ML2 core plugin with the member
variable defined in the superclass.  It also addresses
some problems with the l3 plugin unit tests (still
can't run them individually using tox, but they will
run when .tox/py27/bin/activate is sourced and
python -m testtools.run is used).

Signed-off-by: Thomas Bachman tbachman@yahoo.com
