### PR TITLE
Fix travis CI test failure.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,7 @@ hacking<0.11,>=0.10.0
 
 cliff<1.11.0,>=1.10.0 # Apache-2.0
 coverage>=3.6
-fixtures<1.3.0,>=0.3.14
+fixtures<=1.3.0,>=0.3.14
 mock<1.1.0,>=1.0
 python-subunit>=0.0.18
 requests-mock>=0.6.0 # Apache-2.0


### PR DESCRIPTION
This is fixs the travis CI test environment, which is
failing due to an unmet requirement (fixtures 1.2.0
versus 1.3.0)

Signed-off-by: Thomas Bachman tbachman@yahoo.com
