### PR TITLE
Check subnet constraints

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/config.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/config.py
@@ -92,6 +92,9 @@ apic_opts = [
     cfg.BoolOpt('single_tenant_mode', default=True,
                 help=_("All the Openstack tenants will be described by a "
                        "single ACI tenant.")),
+    cfg.StrOpt('network_constraints_filename',
+               default=None,
+               help=_("Complete path of file containing network constraints")),
 ]
 
 

--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -45,6 +45,8 @@ from oslo_config import cfg
 from oslo_log import log as logging
 
 from apic_ml2.neutron.db import port_ha_ipaddress_binding as ha_ip_db
+from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import (
+    network_constraints as net_cons)
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import apic_model
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import apic_sync
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import attestation
@@ -85,6 +87,11 @@ class CidrOverlapsApicExternalSubnet(n_exc.BadRequest):
 class WouldRequireNAT(n_exc.BadRequest):
     message = _("Setting gateway on router would require address translation, "
                 "but NAT-ing is disabled for external network %(ext_net)s.")
+
+
+class SubnetDisallowedByNetConstraints(n_exc.BadRequest):
+    message = _("Network constraints disallow creation of subnet %(cidr)s "
+                "in network %(net)s")
 
 
 class NameMapper(object):
@@ -246,6 +253,10 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
         self._l3_plugin = None
         self._db_plugin = None
         self.attestator = attestation.EndpointAttestator(self.apic_manager)
+        net_cons_source = cfg.CONF.ml2_cisco_apic.network_constraints_filename
+        if net_cons_source is not None:
+            net_cons_source = net_cons.ConfigFileSource(net_cons_source)
+        self.net_cons = net_cons.NetworkConstraints(net_cons_source)
 
     def _setup_opflex_rpc_listeners(self):
         self.opflex_endpoints = [o_rpc.GBPServerRpcCallback(self)]
@@ -916,6 +927,13 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
         subnet = context.current
         network = context._plugin.get_network(context._plugin_context,
                                               subnet['network_id'])
+        context.subnet_scope = self.net_cons.get_subnet_scope(
+            str(self.name_mapper.tenant(context, network['tenant_id'])),
+            network['name'],
+            subnet['cidr'])
+        if context.subnet_scope == net_cons.SCOPE_DENY:
+            raise SubnetDisallowedByNetConstraints(cidr=subnet['cidr'],
+                                                   net=network['name'])
         if network.get('router:external'):
             ext_info = self.apic_manager.ext_net_dict.get(network['name'])
             if ext_info:
@@ -937,7 +955,8 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
             tenant_id, network_id, gateway_ip = info
             # Create subnet on BD
             self.apic_manager.ensure_subnet_created_on_apic(
-                tenant_id, network_id, gateway_ip)
+                tenant_id, network_id, gateway_ip,
+                scope=getattr(context, 'subnet_scope', None))
         self.notify_subnet_update(context.current)
 
     @sync_init

--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/network_constraints.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/network_constraints.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2016 Cisco Systems Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import netaddr
+import os
+
+from oslo_config import cfg
+from oslo_log import log as logging
+
+
+LOG = logging.getLogger(__name__)
+
+SCOPE_PUBLIC = 'public'
+SCOPE_PRIVATE = 'private'
+SCOPE_DENY = 'deny'
+
+
+class NetworkConstraintsSource(object):
+    def __init__(self):
+        pass
+
+    def get_subnet_constraints(self, tenant, network):
+        """Returns pair (default-subnet-scope, scope-dict-for-network) """
+        return (None, None)
+
+
+class NetworkConstraints(object):
+    def __init__(self, constraints_source):
+        self.source = constraints_source
+
+    def get_subnet_scope(self, tenant, network, cidr):
+        scope = None
+        cidr = netaddr.IPNetwork(cidr)
+        if self.source:
+            def_scope, constraints = (
+                self.source.get_subnet_constraints(tenant, network))
+            scope = def_scope or scope
+            if constraints:
+                if cidr in (constraints.get('deny') or netaddr.IPSet()):
+                    return SCOPE_DENY
+                elif cidr in (constraints.get('private') or netaddr.IPSet()):
+                    return SCOPE_PRIVATE
+                elif cidr in (constraints.get('public') or netaddr.IPSet()):
+                    return SCOPE_PUBLIC
+                else:
+                    scope = constraints.get('default') or scope
+        return scope
+
+
+class ConfigFileSource(NetworkConstraintsSource):
+    def __init__(self, config_file):
+        self.config_file = config_file
+        self.last_refresh_time = 0
+        self.subnet_default_scope = None
+        self.subnet_constraints = {}
+        self._refresh()
+
+    def get_subnet_constraints(self, tenant, network):
+        self._refresh()
+        return (self.subnet_default_scope,
+                self.subnet_constraints.get((tenant, network), {}))
+
+    def _refresh(self):
+        try:
+            mod_time = os.path.getmtime(self.config_file)
+        except os.error as e:
+            LOG.warning('Failed to read file modification time: %s', e)
+            return
+        if self.last_refresh_time < mod_time:
+            self._parse_file()
+            self.last_refresh_time = mod_time
+
+    def _parse_file(self):
+        cfg_parser = cfg.MultiConfigParser()
+        try:
+            cfg_parser.read([self.config_file])
+        except Exception as e:
+            LOG.warning('Failed to parse file %(file)s: %(exc)s',
+                        {'file': self.config_file, 'exc': e})
+            return
+
+        def sanitize_scope(scope):
+            if scope:
+                scope = scope.strip().lower()
+                if scope in [SCOPE_PUBLIC, SCOPE_PRIVATE, SCOPE_DENY]:
+                    return scope
+            return None
+
+        def parse_cidr_list(cidrs):
+            try:
+                return netaddr.IPSet(
+                    [c for c in cidrs.split(',') if c.strip()])
+            except Exception as e:
+                LOG.warning('Failed to parse CIDRs: %(cidr)s: %(exc)s',
+                            {'cidr': cidrs, 'exc': e})
+                return None
+
+        def_scope = None
+        constraints = {}
+        LOG.debug('Parsing network constraints file %s', self.config_file)
+        for cfg_file in cfg_parser.parsed:
+            for section_name in cfg_file.keys():
+                if section_name == 'DEFAULT':
+                    def_scope = sanitize_scope(
+                        cfg_file[section_name].get('subnet_scope', [None])[0])
+                    LOG.debug('Default subnet scope: %s', def_scope)
+                else:
+                    net = tuple(section_name.split('/', 1))
+                    if len(net) < 2:
+                        continue
+                    constraints[net] = {}
+                    for k, v in cfg_file[section_name].iteritems():
+                        k = k.lower()
+                        if k in ['public', 'private', 'deny']:
+                            constraints[net][k] = parse_cidr_list(v[0])
+                        elif k == 'default':
+                            constraints[net][k] = sanitize_scope(v[0])
+                    LOG.debug('Constraints for network %(n)s - %(c)s',
+                              {'n': net, 'c': constraints[net]})
+        self.subnet_default_scope = def_scope
+        self.subnet_constraints = constraints

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -17,6 +17,7 @@ import base64
 import hashlib
 import hmac
 import sys
+import tempfile
 
 from apicapi import apic_client
 from apicapi import apic_manager
@@ -688,6 +689,68 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
             for p in sorted([p1['id'], p2['id'], p4['id']])]
         self._check_call_list(
             expected_calls, self.driver.notify_port_update.call_args_list)
+
+
+class TestCiscoApicML2SubnetScope(ApicML2IntegratedTestCase):
+    def setUp(self, service_plugins=None):
+        with tempfile.NamedTemporaryFile(delete=False) as fd:
+            self.cons_file_name = fd.name
+        self.override_conf('network_constraints_filename',
+                           self.cons_file_name,
+                           'ml2_cisco_apic')
+        super(TestCiscoApicML2SubnetScope, self).setUp(service_plugins)
+
+    def test_subnet_scope(self):
+        cons_data = """
+[DEFAULT]
+subnet_scope = deny
+
+[%s/net1]
+public = 10.10.10.1/24,10.10.20.1/24
+private = 20.10.10.0/28,20.10.20.0/24
+deny = 30.10.10.0/24
+default = private
+            """ % (mocked.APIC_TENANT)
+        self.driver.net_cons.source.last_refresh_time = 0
+        with open(self.cons_file_name, 'w') as fd:
+            fd.write(cons_data)
+
+        self.mgr.ensure_subnet_created_on_apic = mock.Mock()
+        self.driver.name_mapper.aci_mapper.min_suffix = 0
+        net1 = self.create_network(
+            name='net1', tenant_id=mocked.APIC_TENANT,
+            expected_res_status=201)['network']
+        net2 = self.create_network(
+            name='net2', tenant_id=mocked.APIC_TENANT,
+            expected_res_status=201)['network']
+
+        for cidr in ['10.10.10.0/28', '20.10.10.0/26', '40.10.10.0/30']:
+            self.create_subnet(
+                tenant_id=mocked.APIC_TENANT,
+                network_id=net1['id'], cidr=cidr, ip_version=4)
+        exp_calls = [
+            mock.call(
+                self._tenant(), self._scoped_name('net1'),
+                '10.10.10.1/28', scope='public'),
+            mock.call(
+                self._tenant(), self._scoped_name('net1'),
+                '20.10.10.1/26', scope='private'),
+            mock.call(
+                self._tenant(), self._scoped_name('net1'),
+                '40.10.10.1/30', scope='private')]
+        self._check_call_list(
+            exp_calls, self.mgr.ensure_subnet_created_on_apic.call_args_list)
+
+        res = self.create_subnet(
+            tenant_id=mocked.APIC_TENANT,
+            network_id=net1['id'], cidr='30.10.10.0/24', ip_version=4,
+            expected_res_status=500)
+        self.assertEqual('MechanismDriverError', res['NeutronError']['type'])
+        res = self.create_subnet(
+            tenant_id=mocked.APIC_TENANT,
+            network_id=net2['id'], cidr='10.10.10.0/24', ip_version=4,
+            expected_res_status=500)
+        self.assertEqual('MechanismDriverError', res['NeutronError']['type'])
 
 
 class MechanismRpcTestCase(ApicML2IntegratedTestBase):
@@ -1570,7 +1633,8 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         self.driver.create_subnet_postcommit(subnet_ctx)
         mgr.ensure_subnet_created_on_apic.assert_called_once_with(
             self._tenant(), self._scoped_name(mocked.APIC_NETWORK),
-            '%s/%s' % (SUBNET_GATEWAY, SUBNET_NETMASK))
+            '%s/%s' % (SUBNET_GATEWAY, SUBNET_NETMASK),
+            scope=None)
 
     def test_create_subnet_nogw_postcommit(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,
@@ -1595,7 +1659,8 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         mgr.ensure_subnet_created_on_apic.assert_called_once_with(
             self._tenant(),
             "EXT-bd-%s" % self._scoped_name(mocked.APIC_NETWORK),
-            '%s/%s' % (SUBNET_GATEWAY, SUBNET_NETMASK))
+            '%s/%s' % (SUBNET_GATEWAY, SUBNET_NETMASK),
+            scope=None)
 
     def test_delete_external_subnet_postcommit(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_network_constraints.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_network_constraints.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2016 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import netaddr
+import tempfile
+import time
+
+from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import (
+    network_constraints as anc)
+from neutron.tests import base
+
+
+class TestNetworkConstraints(base.BaseTestCase):
+
+    class MockSource(anc.NetworkConstraintsSource):
+        def get_subnet_constraints(self, tenant, network):
+            def_scope = anc.SCOPE_PUBLIC
+            cons = None
+            s1 = netaddr.IPSet(['10.10.10.1/24', '10.10.20.1/24'])
+            s2 = netaddr.IPSet(['20.10.10.0/24', '20.10.20.0/24'])
+            s3 = netaddr.IPSet(['30.10.10.0/24', '30.10.20.0/24'])
+            c = netaddr.IPSet(['5.5.0.0/16'])
+            if tenant == 't1' and network == 'net1':
+                cons = {'public': s1, 'private': s2, 'deny': s3,
+                        'default': 'private'}
+            elif tenant == 't1' and network == 'net2':
+                cons = {'default': 'deny'}
+            elif tenant == 't1' and network == 'net3':
+                cons = {}
+            elif tenant == 't1' and network == 'net4':
+                cons = {'private': [], 'deny': None, 'default': None}
+            elif tenant == 't2' and network == 'net1':
+                cons = {'public': s1 | c, 'private': s2 | c, 'deny': s3 | c}
+            elif tenant == 't2' and network == 'net2':
+                cons = {'public': s1 | c, 'private': s2 | c, 'deny': []}
+            elif tenant == 't2' and network == 'net3':
+                cons = {'public': s1 | c, 'private': s2, 'deny': s3 | c}
+            elif tenant == 't2' and network == 'net4':
+                cons = {'public': s1, 'private': s2 | c, 'deny': s3 | c}
+            return (def_scope, cons)
+
+    def setUp(self):
+        super(TestNetworkConstraints, self).setUp()
+        self.net_cons = anc.NetworkConstraints(self.MockSource())
+
+    def test_no_source(self):
+        net_cons = anc.NetworkConstraints(None)
+        self.assertEqual(
+            None,
+            net_cons.get_subnet_scope('t1', 'net1', '10.10.10.0/28'))
+        self.assertEqual(
+            None,
+            net_cons.get_subnet_scope('t1', 'net1', '0.0.0.0/0'))
+
+    def test_subnet_scope(self):
+        self.assertEqual(
+            anc.SCOPE_PUBLIC,
+            self.net_cons.get_subnet_scope('t1', 'net1', '10.10.10.0/28'))
+        self.assertEqual(
+            anc.SCOPE_PUBLIC,
+            self.net_cons.get_subnet_scope('t1', 'net1', '10.10.20.0/28'))
+
+        self.assertEqual(
+            anc.SCOPE_PRIVATE,
+            self.net_cons.get_subnet_scope('t1', 'net1', '20.10.10.1/28'))
+        self.assertEqual(
+            anc.SCOPE_PRIVATE,
+            self.net_cons.get_subnet_scope('t1', 'net1', '20.10.20.1/28'))
+
+        self.assertEqual(
+            anc.SCOPE_DENY,
+            self.net_cons.get_subnet_scope('t1', 'net1', '30.10.10.1/28'))
+        self.assertEqual(
+            anc.SCOPE_DENY,
+            self.net_cons.get_subnet_scope('t1', 'net1', '30.10.20.1/28'))
+
+    def test_network_default_subnet_scope(self):
+        self.assertEqual(
+            anc.SCOPE_PRIVATE,
+            self.net_cons.get_subnet_scope('t1', 'net1', '10.10.20.0/23'))
+        self.assertEqual(
+            anc.SCOPE_PRIVATE,
+            self.net_cons.get_subnet_scope('t1', 'net1', '40.10.10.1/28'))
+        self.assertEqual(
+            anc.SCOPE_DENY,
+            self.net_cons.get_subnet_scope('t1', 'net2', '10.10.10.1/28'))
+
+    def test_global_default_subnet_scope(self):
+        self.assertEqual(
+            anc.SCOPE_PUBLIC,
+            self.net_cons.get_subnet_scope('t1', 'net3', '10.10.10.1/24'))
+        self.assertEqual(
+            anc.SCOPE_PUBLIC,
+            self.net_cons.get_subnet_scope('t1', 'net4', '20.10.10.1/24'))
+        self.assertEqual(
+            anc.SCOPE_PUBLIC,
+            self.net_cons.get_subnet_scope('foo', 'bar', '10.10.10.1/24'))
+
+    def test_overlapping_subnet_scope(self):
+        self.assertEqual(
+            anc.SCOPE_DENY,
+            self.net_cons.get_subnet_scope('t2', 'net1', '5.5.10.128/25'))
+        self.assertEqual(
+            anc.SCOPE_PRIVATE,
+            self.net_cons.get_subnet_scope('t2', 'net2', '5.5.10.128/25'))
+        self.assertEqual(
+            anc.SCOPE_DENY,
+            self.net_cons.get_subnet_scope('t2', 'net3', '5.5.10.128/25'))
+        self.assertEqual(
+            anc.SCOPE_DENY,
+            self.net_cons.get_subnet_scope('t2', 'net4', '5.5.10.128/25'))
+
+
+class TestConfigFileSource(base.BaseTestCase):
+    def setUp(self):
+        super(TestConfigFileSource, self).setUp()
+        self.file_data = """
+[DEFAULT]
+subnet_scope = public
+
+[t1/net1]
+public = 10.10.10.1/24 ,   10.10.20.1/24 ,
+private = 20.10.10.0.0/1,20.10.20.0/24
+deny = 20.10.10.0/24
+default = foo
+
+[t1/net2]
+public = 10.10.10.1/24
+private = 20.10.10.0/31,20.10.10.0/24
+default = deny
+
+[t1/net3]
+default = deny
+
+[t1:net_unk]
+default = deny
+"""
+        with tempfile.NamedTemporaryFile(delete=False) as fd:
+            self.cons_file_name = fd.name
+
+    def _write_constraints_file(self, data):
+        with open(self.cons_file_name, 'w') as fd:
+            fd.write(data)
+
+    def test_non_existent(self):
+        ncs = anc.ConfigFileSource("foo")
+        self.assertEqual((None, {}), ncs.get_subnet_constraints('t', 'n'))
+
+    def test_no_default_scope(self):
+        self._write_constraints_file(self.file_data.replace('DEFAULT', 'a'))
+        ncs = anc.ConfigFileSource(self.cons_file_name)
+        self.assertEqual((None, {'default': 'deny'}),
+                         ncs.get_subnet_constraints('t1', 'net3'))
+
+    def test_parse(self):
+        self._write_constraints_file(self.file_data)
+        ncs = anc.ConfigFileSource(self.cons_file_name)
+        self.assertEqual(
+            (anc.SCOPE_PUBLIC,
+             {'public': netaddr.IPSet(['10.10.10.1/24', '10.10.20.1/24']),
+              'private': None,
+              'deny': netaddr.IPSet(['20.10.10.0/24']),
+              'default': None}),
+            ncs.get_subnet_constraints('t1', 'net1'))
+
+        self.assertEqual(
+            (anc.SCOPE_PUBLIC,
+             {'public': netaddr.IPSet(['10.10.10.1/24']),
+              'private': netaddr.IPSet(['20.10.10.0/24']),
+              'default': 'deny'}),
+            ncs.get_subnet_constraints('t1', 'net2'))
+
+        self.assertEqual((anc.SCOPE_PUBLIC, {}),
+                         ncs.get_subnet_constraints('t1', 'net_unk'))
+
+    def test_auto_refresh(self):
+        self._write_constraints_file(self.file_data)
+        ncs = anc.ConfigFileSource(self.cons_file_name)
+        self.assertEqual((anc.SCOPE_PUBLIC, {'default': 'deny'}),
+                         ncs.get_subnet_constraints('t1', 'net3'))
+        time.sleep(0.1)
+
+        data = self.file_data.replace('subnet_scope = public',
+                                      'subnet_scope = deny')
+        data = data.replace('t1/net3', 't2/net3')
+        self._write_constraints_file(data)
+
+        self.assertEqual((anc.SCOPE_DENY, {}),
+                         ncs.get_subnet_constraints('t1', 'net3'))
+        self.assertEqual((anc.SCOPE_DENY, {'default': 'deny'}),
+                         ncs.get_subnet_constraints('t2', 'net3'))

--- a/etc/neutron/plugins/ml2/cisco_apic_network_constraints.ini
+++ b/etc/neutron/plugins/ml2/cisco_apic_network_constraints.ini
@@ -1,0 +1,56 @@
+[DEFAULT]
+
+# The subnet scope to use on APIC if no other constraint
+# has been explicitly specified. Valid values are
+# public, private or deny.
+# public -> Subnet will be advertised externally
+# private -> Subnet is private to VRF
+# deny -> Disallow creation of subnet
+# subnet_scope = public|private|deny
+
+
+# Tenant (project) specific constraints and network specific
+# constraints are described in sections of their own.
+#
+# A tenant section looks like:
+# [tenant-name]
+# ...
+#
+# A network section looks like:
+# [tenant-name/network-name]
+# ...
+#
+# Network-specific constraints, when specified, take preference over
+# tenant-specific constraints.
+
+# Both sections may have the following configuration keys:
+# deny -> Comma-separated list of CIDRs. If the requested
+#         subnet overlaps with a deny CIDR, then creation of
+#         the subnet is disallowed.
+# private -> Comma-separated list of CIDRs. If the requested
+#           subnet is contained within a private CIDR, then
+#           the subnet will be created with 'private' scope
+#           (i.e. private to the corresponding VRF).
+# public -> Comma-separated list of CIDRs. If the requested
+#           subnet is contained within a public CIDR, then
+#           the subnet will be created with 'public' scope
+#           (i.e. advertised externally).
+# default -> The scope to use if the subnet does not match
+#            any of the explicitly specified CIDRs. Valid
+#            values are public, private or deny.
+#
+# When deciding subnet scope, the order of preference is deny,
+# private, public. Thus if the requested subnet is present in
+# both private and public CIDRs, the scope used will be private.
+#
+# Example:
+#
+# [tenant1/network1]
+# public = 10.10.10.0/24, 10.10.20.0/28
+# deny = 30.10.0.0/16
+# default = private
+#
+# [tenant1]
+# private = 50.50.50.0/26
+# default = deny
+

--- a/etc/neutron/plugins/ml2/ml2_conf_cisco_apic.ini
+++ b/etc/neutron/plugins/ml2/ml2_conf_cisco_apic.ini
@@ -29,6 +29,9 @@
 # apic_agent_report_interval = 30
 # apic_agent_poll_interval = 2
 
+# File where network constraints are described (defaults to no constraints)
+# network_constraints_filename = /etc/neutron/plugins/ml2/cisco_apic_network_constraints.ini
+
 # Use integrated topology service for better host mobility in ACI.
 # If se to True, the apic_topology service should be disabled, while the agents
 # will keep working as usual.

--- a/rpm/neutron-ml2-driver-apic.spec.in
+++ b/rpm/neutron-ml2-driver-apic.spec.in
@@ -91,6 +91,7 @@ apic-ml2-db-manage --config-file /etc/neutron/neutron.conf upgrade head
 %{_unitdir}/%{host_agent}
 %{_unitdir}/%{service_agent}
 %{_sysconfdir}/neutron/plugins/ml2/ml2_conf_cisco_apic.ini
+%{_sysconfdir}/neutron/plugins/ml2/cisco_apic_network_constraints.ini
 %{_sysconfdir}/neutron/rootwrap.d/cisco-apic.filters
 
 %changelog

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,8 @@ data_files =
         etc/neutron/rootwrap.d/cisco-apic.filters
     etc/neutron/plugins/ml2 =
 	etc/neutron/plugins/ml2/ml2_conf_cisco_apic.ini
+    etc/neutron/plugins/ml2 =
+	etc/neutron/plugins/ml2/cisco_apic_network_constraints.ini
 
 [build_sphinx]
 source-dir = doc/source


### PR DESCRIPTION
Add the ability to deny creation of subnets with
specific CIDRs. Also allow setting the APIC subnet scope.
Both pieces of information are read from a 'network
constraints' file; the filename is specified as
a config option.

Signed-off-by: Amit Bose bose@noironetworks.com
(cherry picked from commit 60efefd672ee3cb3ceea595ac629127afcc04b98)
