### PR TITLE
Added DVS VIF type support.

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/constants.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/constants.py
@@ -13,8 +13,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+AGENT_TYPE_DVS = 'DVS agent'
 APIC_SYNC_NETWORK = 'apic-sync-network'
 HOST_SNAT_NETWORK_PREFIX = 'host-snat-network-for-internal-use-'
 HOST_SNAT_POOL = 'host-snat-pool-for-internal-use'
 HOST_SNAT_POOL_PORT = 'host-snat-pool-port-for-internal-use'
 DEVICE_OWNER_SNAT_PORT = 'host-snat-pool-port-device-owner-internal-use'
+VIF_TYPE_DVS = 'dvs'

--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -30,6 +30,7 @@ from neutron.db import allowedaddresspairs_db as n_addr_pair_db
 from neutron.db import db_base_plugin_v2 as n_db
 from neutron.db import models_v2
 from neutron.extensions import portbindings
+from neutron.i18n import _LW
 from neutron import manager
 from neutron.plugins.common import constants
 from neutron.plugins.ml2 import db as ml2_db
@@ -190,10 +191,88 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
             ofcst.AGENT_TYPE_OPFLEX_OVS)
         ha_ip_db.HAIPOwnerDbMixin.__init__(self)
 
+    def _agent_bind_port(self, context, agent_list):
+        """Attempt port binding per agent.
+
+           Perform the port binding for a given agent.
+           Returns True if bound successfully.
+        """
+        for agent in agent_list:
+            LOG.debug("Checking agent: %s", agent)
+            if agent['alive']:
+                for segment in context.segments_to_bind:
+                    if self.try_to_bind_segment_for_agent(context, segment,
+                                                          agent):
+                        LOG.debug("Bound using segment: %s", segment)
+                        return True
+            else:
+                LOG.warning(_LW("Refusing to bind port %(pid)s to dead agent: "
+                                "%(agent)s"),
+                            {'pid': context.current['id'], 'agent': agent})
+        return False
+
+    def bind_port(self, context):
+        """Get port binding per host.
+
+           Overriding the superclass implementation
+           in order to support multiple agent types
+           in a single mechanism driver (DVS and OpFlex)
+        """
+
+        LOG.debug("Attempting to bind port %(port)s on "
+                  "network %(network)s",
+                  {'port': context.current['id'],
+                   'network': context.network.current['id']})
+        vnic_type = context.current.get(portbindings.VNIC_TYPE,
+                                        portbindings.VNIC_NORMAL)
+        if vnic_type not in self.supported_vnic_types:
+            LOG.debug("Refusing to bind due to unsupported vnic_type: %s",
+                      vnic_type)
+            return
+
+        # Attempt to bind ports for DVS agents on nova compute nodes
+        # first.  This allows running network agents (dhcp, metadata)
+        # that typically run on a network node using an OpFlex agent to
+        # co-exist with a nova-compute service for ESX, which hosts
+        # the DVS agent.
+        if context.current['device_owner'] == 'compute:nova':
+            agent_list = context.host_agents(acst.AGENT_TYPE_DVS)
+            if self._agent_bind_port(context, agent_list):
+                return
+
+        # It either wwasn't a DVS binding, or there wasn't a DVS
+        # agent on the binding host (could be the case in a hybrid
+        # environment supporting KVM and ESX compute). Go try for
+        # OpFlex agents.
+        agent_list = context.host_agents(self.agent_type)
+        self._agent_bind_port(context, agent_list)
+
+    def _set_dvs_vif_details(self, context):
+        """Populate VIF details for DVS VIFs.
+
+           For DVS VIFs, provide the portgroup along
+           with the security groups setting
+        """
+
+        tenant_id = context.current.get('tenant_id')
+        network_id = context.current.get('network_id')
+        if tenant_id and network_id:
+            network = self.name_mapper.network(context, network_id)
+            project_name = self.name_mapper.tenant(None, tenant_id)
+            sg_enabled = self.vif_details[portbindings.CAP_PORT_FILTER]
+            return {portbindings.CAP_PORT_FILTER: sg_enabled,
+                    'dvs_port_group': (cfg.CONF.apic_system_id +
+                                       '|' + str(project_name) +
+                                       '|' + str(network))}
+
     def try_to_bind_segment_for_agent(self, context, segment, agent):
         if self.check_segment_for_agent(segment, agent):
-            context.set_binding(
-                segment[api.ID], self.vif_type, self.vif_details)
+            vif_type = self.vif_type
+            vif_details = self.vif_details
+            if agent['agent_type'] == acst.AGENT_TYPE_DVS:
+                vif_type = acst.VIF_TYPE_DVS
+                vif_details = self._set_dvs_vif_details(context)
+            context.set_binding(segment[api.ID], vif_type, vif_details)
             return True
         else:
             return False

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -70,6 +70,11 @@ AGENT_CONF = {'alive': True, 'binary': 'somebinary',
               'topic': 'sometopic', 'agent_type': AGENT_TYPE,
               'configurations': {'opflex_networks': None,
                                  'bridge_mappings': {'physnet1': 'br-eth1'}}}
+AGENT_TYPE_DVS = acst.AGENT_TYPE_DVS
+AGENT_CONF_DVS = {'alive': True, 'binary': 'anotherbinary',
+                  'topic': 'anothertopic', 'agent_type': AGENT_TYPE_DVS,
+                  'configurations': {'bridge_mappings': {'physnet1':
+                                                         'br-eth1'}}}
 
 
 def echo(context, id, prefix=''):
@@ -139,13 +144,25 @@ class ApicML2IntegratedTestBase(test_plugin.NeutronDbPluginV2TestCase,
             'dirtylittlesecret')
         self.driver.notifier = mock.Mock()
 
-    def _bind_port_to_host(self, port_id, host):
+    def _register_agent(self, host, agent_cfg=AGENT_CONF):
         plugin = manager.NeutronManager.get_plugin()
         ctx = context.get_admin_context()
         agent = {'host': host}
-        agent.update(AGENT_CONF)
+        agent.update(agent_cfg)
         plugin.create_or_update_agent(ctx, agent)
-        data = {'port': {'binding:host_id': host, 'device_owner': 'compute:',
+
+    def _bind_port_to_host(self, port_id, host):
+        data = {'port': {'binding:host_id': host,
+                         'device_owner': 'compute:nova',
+                         'device_id': 'someid'}}
+        # Create EP with bound port
+        req = self.new_update_request('ports', data, port_id,
+                                      self.fmt)
+        return self.deserialize(self.fmt, req.get_response(self.api))
+
+    def _bind_net_port_to_host(self, port_id, host):
+        data = {'port': {'binding:host_id': host,
+                         'device_owner': 'network:dhcp',
                          'device_id': 'someid'}}
         # Create EP with bound port
         req = self.new_update_request('ports', data, port_id,
@@ -210,6 +227,7 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
                           is_admin_context=True, expected_res_status=200)
 
     def test_port_on_shared_non_opflex_network(self):
+        self._register_agent('h1')
         net = self.create_network(
             tenant_id='onetenant', expected_res_status=201, shared=True,
             is_admin_context=True)['network']
@@ -230,6 +248,7 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
                     neutron_tenant='onetenant'))
 
     def test_port_on_shared_opflex_network(self):
+        self._register_agent('h1')
         net = self.create_network(
             tenant_id='onetenant', expected_res_status=201, shared=True,
             is_admin_context=True)['network']
@@ -254,6 +273,7 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
             self.assertEqual(sub['subnet']['id'], details['subnets'][0]['id'])
 
     def test_enhanced_subnet_options(self):
+        self._register_agent('h1')
         net = self.create_network(
             tenant_id='onetenant', expected_res_status=201, shared=True,
             is_admin_context=True)['network']
@@ -376,6 +396,7 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
         self.assertFalse(self.synchronizer._sync_base.called)
 
     def test_attestation(self):
+        self._register_agent('h1')
         net = self.create_network(
             tenant_id='onetenant', expected_res_status=201)['network']
         expected_attestation = {'ports': [{'switch': '102',
@@ -421,6 +442,7 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
             self.assertEqual(expected_mac, observed_mac)
 
     def test_dhcp_notifications_on_create(self):
+        self._register_agent('h1')
         net = self.create_network(
             expected_res_status=201, shared=True,
             is_admin_context=True)['network']
@@ -447,6 +469,7 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
                         self.driver.notifier.port_update.call_args_list)
 
     def test_dhcp_notifications_on_update(self):
+        self._register_agent('h1')
         net = self.create_network(
             expected_res_status=201, shared=True,
             is_admin_context=True)['network']
@@ -593,6 +616,8 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
             exp_calls, self.driver.notify_port_update.call_args_list)
 
     def test_gbp_details_for_allowed_address_pair(self):
+        self._register_agent('h1')
+        self._register_agent('h2')
         net = self.create_network(
             tenant_id=mocked.APIC_TENANT, expected_res_status=201)['network']
         sub1 = self.create_subnet(
@@ -706,6 +731,8 @@ class MechanismRpcTestCase(ApicML2IntegratedTestBase):
         self.assertIn(('h2', 'static'), peers)
 
     def test_remove_hostlink(self):
+        self._register_agent('h1')
+        self._register_agent('h2')
         # Test removal of one link
         self._add_hosts_to_apic(3)
         self.driver.apic_manager.delete_path = mock.Mock()
@@ -735,6 +762,7 @@ class MechanismRpcTestCase(ApicML2IntegratedTestBase):
                     0, self.driver.apic_manager.delete_path.call_count)
 
     def test_remove_hostlink_vpc(self):
+        self._register_agent('h1')
         self._add_hosts_to_apic(3, vpc=True)
         self.driver.apic_manager.delete_path = mock.Mock()
         net = self.create_network()['network']
@@ -761,6 +789,9 @@ class MechanismRpcTestCase(ApicML2IntegratedTestBase):
                                      '1'))
 
     def test_add_hostlink(self):
+        self._register_agent('h1')
+        self._register_agent('h2')
+        self._register_agent('rhel03')
         # Test removal of one link
         self._add_hosts_to_apic(2)
         net = self.create_network()['network']
@@ -799,6 +830,7 @@ class MechanismRpcTestCase(ApicML2IntegratedTestBase):
                             net['provider:segmentation_id']))
 
     def test_update_hostlink(self):
+        self._register_agent('h1')
         self._add_hosts_to_apic(1)
 
         net1 = self.create_network()['network']
@@ -1772,6 +1804,125 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
             port['device_owner'] = n_constants.DEVICE_OWNER_ROUTER_GW
             port['device_id'] = mocked.APIC_ROUTER
         return FakePortContext(port, network_ctx)
+
+
+class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
+
+    def setUp(self, service_plugins=None):
+        super(ApicML2IntegratedTestCaseDvs, self).setUp(service_plugins)
+        # This is required for the test. Without it,
+        # the ML2 driver's agent_type ends up being a
+        # mocked type, which fails when passed to the
+        # hast_agents() method for the PortContext
+        # (but only for types not defined by the
+        # mechanism driver class itself).
+        self.driver.agent_type = 'Open vSwitch agent'
+
+    def test_bind_port_dvs(self):
+        # Register a DVS agent
+        self._register_agent('h1', agent_cfg=AGENT_CONF_DVS)
+        net = self.create_network(
+            tenant_id='onetenant', expected_res_status=201, shared=True,
+            is_admin_context=True)['network']
+        sub = self.create_subnet(
+            network_id=net['id'], cidr='192.168.0.0/24',
+            ip_version=4, is_admin_context=True)
+        with self.port(subnet=sub, tenant_id='onetenant') as p1:
+            p1 = p1['port']
+            self.assertEqual(net['id'], p1['network_id'])
+            self.mgr.ensure_path_created_for_port = mock.Mock()
+            # Bind port to trigger path binding
+            newp1 = self._bind_port_to_host(p1['id'], 'h1')
+            # Called on the network's tenant
+            expected_pg = (mocked.APIC_SYSTEM_ID + '|' +
+                           net['tenant_id'] + '|' + net['id'])
+            pg = newp1['port']['binding:vif_details']['dvs_port_group']
+            self.assertEqual(pg, expected_pg)
+
+    def test_bind_port_dvs_with_opflex_diff_hosts(self):
+        # Register an OpFlex agent and DVS agent
+        self._register_agent('h1')
+        self._register_agent('h2', agent_cfg=AGENT_CONF_DVS)
+        net = self.create_network(
+            tenant_id='onetenant', expected_res_status=201, shared=True,
+            is_admin_context=True)['network']
+        sub = self.create_subnet(
+            network_id=net['id'], cidr='192.168.0.0/24',
+            ip_version=4, is_admin_context=True)
+        # Bind a VLAN port after registering a DVS agent
+        with self.port(subnet=sub, tenant_id='onetenant') as p1:
+            p1 = p1['port']
+            self.assertEqual(net['id'], p1['network_id'])
+            self.mgr.ensure_path_created_for_port = mock.Mock()
+            # Bind port to trigger path binding
+            newp1 = self._bind_port_to_host(p1['id'], 'h2')
+            # Called on the network's tenant
+            expected_pg = (mocked.APIC_SYSTEM_ID + '|' +
+                           net['tenant_id'] + '|' + net['id'])
+            vif_det = newp1['port']['binding:vif_details']
+            self.assertIsNotNone(vif_det.get('dvs_port_group', None))
+            self.assertEqual(expected_pg, vif_det.get('dvs_port_group'))
+
+    def test_bind_ports_opflex_same_host(self):
+        # Register an OpFlex agent and DVS agent
+        self._register_agent('h1')
+        net = self.create_network(
+            tenant_id='onetenant', expected_res_status=201, shared=True,
+            is_admin_context=True)['network']
+        sub = self.create_subnet(
+            network_id=net['id'], cidr='192.168.0.0/24',
+            ip_version=4, is_admin_context=True)
+        # Bind a VLAN port after registering a DVS agent
+        with self.port(subnet=sub, tenant_id='onetenant') as p1:
+            p1 = p1['port']
+            self.assertEqual(net['id'], p1['network_id'])
+            self.mgr.ensure_path_created_for_port = mock.Mock()
+            # Bind port to trigger path binding
+            newp1 = self._bind_port_to_host(p1['id'], 'h1')
+            # Called on the network's tenant
+            vif_det = newp1['port']['binding:vif_details']
+            self.assertIsNone(vif_det.get('dvs_port_group', None))
+        with self.port(subnet=sub, tenant_id='onetenant') as p2:
+            p2 = p2['port']
+            self.assertEqual(net['id'], p2['network_id'])
+            self.mgr.ensure_path_created_for_port = mock.Mock()
+            # Bind port to trigger path binding
+            newp2 = self._bind_net_port_to_host(p2['id'], 'h1')
+            # Called on the network's tenant
+            vif_det = newp2['port']['binding:vif_details']
+            self.assertIsNone(vif_det.get('dvs_port_group', None))
+
+    def test_bind_ports_dvs_with_opflex_same_host(self):
+        # Register an OpFlex agent and DVS agent
+        self._register_agent('h1', agent_cfg=AGENT_CONF_DVS)
+        net = self.create_network(
+            tenant_id='onetenant', expected_res_status=201, shared=True,
+            is_admin_context=True)['network']
+        sub = self.create_subnet(
+            network_id=net['id'], cidr='192.168.0.0/24',
+            ip_version=4, is_admin_context=True)
+        # Bind a VLAN port after registering a DVS agent
+        with self.port(subnet=sub, tenant_id='onetenant') as p1:
+            p1 = p1['port']
+            self.assertEqual(net['id'], p1['network_id'])
+            self.mgr.ensure_path_created_for_port = mock.Mock()
+            # Bind port to trigger path binding
+            newp1 = self._bind_port_to_host(p1['id'], 'h1')
+            # Called on the network's tenant
+            expected_pg = (mocked.APIC_SYSTEM_ID + '|' +
+                           net['tenant_id'] + '|' + net['id'])
+            vif_det = newp1['port']['binding:vif_details']
+            self.assertIsNotNone(vif_det.get('dvs_port_group', None))
+            self.assertEqual(expected_pg, vif_det.get('dvs_port_group'))
+        with self.port(subnet=sub, tenant_id='onetenant') as p2:
+            p2 = p2['port']
+            self.assertEqual(net['id'], p2['network_id'])
+            self.mgr.ensure_path_created_for_port = mock.Mock()
+            # Bind port to trigger path binding
+            newp2 = self._bind_net_port_to_host(p2['id'], 'h1')
+            # Called on the network's tenant
+            vif_det = newp2['port']['binding:vif_details']
+            self.assertIsNone(vif_det.get('dvs_port_group', None))
 
 
 class ApicML2IntegratedTestCaseSingleVRF(ApicML2IntegratedTestCase):


### PR DESCRIPTION
This modifies the mechanism driver to support port
binding for DVS VIF types. Since mechanism drivers
qualify port binding by only binding for hosts that
are running a matching agent, it adds a constraint
that an OpFlex agent and DVS agent can only exist
on the same host when the OpFlex agent is used for
network services, such as dhcp and metadata agents,
and not compute services (otherwise, binding of ports
for compute would be ambiguous).

Signed-off-by: Thomas Bachman tbachman@yahoo.com
