### PR TITLE
Add support for VMware DVS

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/constants.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/constants.py
@@ -17,4 +17,8 @@ APIC_SYNC_NETWORK = 'apic-sync-network'
 HOST_SNAT_NETWORK_PREFIX = 'host-snat-network-for-internal-use-'
 HOST_SNAT_POOL = 'host-snat-pool-for-internal-use'
 HOST_SNAT_POOL_PORT = 'host-snat-pool-port-for-internal-use'
+# TODO(tbachman) Figure out a better/common place for this
+HYPERVISOR_VCENTER = "VMware vCenter"
 DEVICE_OWNER_SNAT_PORT = 'host-snat-pool-port-device-owner-internal-use'
+# TODO(tbachman) figure out a better/common place for this
+VIF_TYPE_DVS = "dvs"

--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -197,15 +197,55 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
             ofcst.AGENT_TYPE_OPFLEX_OVS)
         ha_ip_db.HAIPOwnerDbMixin.__init__(self)
 
+    def _is_dvs_vif_type(self, context, agent):
+        """Return if this port is a DVS vif
+
+           We need to bind the port as a DVS VIF type
+           when the port belongs to nova, and when there's
+           an OpFlex agent on that (compute) host that's told
+           us it's supporting a VMware hypervisor.
+        """
+        port = context.current
+        if port['device_owner'] == 'compute:nova':
+            hv_type = agent['configurations'].get('hypervisor_type', None)
+            if hv_type and hv_type == acst.HYPERVISOR_VCENTER:
+                return True
+        return False
+
+    def _get_dvs_vif_details(self, context):
+        """Populate VIF details for DVS VIFs.
+
+           For DVS VIFs, provide the portgroup along
+           with the security groups setting
+        """
+
+        # Use default security groups from MD
+        vif_details = ({portbindings.CAP_PORT_FILTER:
+                        self.vif_details[portbindings.CAP_PORT_FILTER]})
+        network_id = context.current.get('network_id')
+        if network_id:
+            network = self.name_mapper.network(context, network_id)
+            net = self._get_plugin().get_network(context._plugin_context,
+                                                 network_id)
+            project_name = self.name_mapper.tenant(None, net['tenant_id'])
+            vif_details['dvs_port_group'] = (cfg.CONF.apic_system_id +
+                                             '|' + str(project_name) +
+                                             '|' + str(network))
+        return vif_details
+
     def try_to_bind_segment_for_agent(self, context, segment, agent):
-        if self.check_segment_for_agent(segment, agent):
-            context.set_binding(
-                segment[api.ID], self.vif_type, self.vif_details)
+        if self._check_segment_for_agent(segment, agent):
+            vif_type = self.vif_type
+            vif_details = self.vif_details
+            if self._is_dvs_vif_type(context, agent):
+                vif_type = acst.VIF_TYPE_DVS
+                vif_details = self._get_dvs_vif_details(context)
+            context.set_binding(segment[api.ID], vif_type, vif_details)
             return True
         else:
             return False
 
-    def check_segment_for_agent(self, segment, agent):
+    def _check_segment_for_agent(self, segment, agent):
         network_type = segment[api.NETWORK_TYPE]
         if network_type == ofcst.TYPE_OPFLEX:
             opflex_mappings = agent['configurations'].get('opflex_networks',

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_common.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_common.py
@@ -206,7 +206,7 @@ class ConfigMixin(object):
     def __init__(self):
         self.mocked_parser = None
 
-    def set_up_mocks(self):
+    def set_up_mocks(self, ml2_opts=None):
         # Mock the configuration file
         base.BaseTestCase.config_parse()
 
@@ -217,10 +217,12 @@ class ConfigMixin(object):
         cfg.CONF.keystone_authtoken = KEYSTONE_TOKEN
 
         # Configure the ML2 mechanism drivers and network types
-        ml2_opts = {
-            'mechanism_drivers': ['openvswitch', 'cisco_apic_ml2'],
-            'tenant_network_types': ['vlan'],
-        }
+        if ml2_opts is None:
+            ml2_opts = {
+                'mechanism_drivers': ['openvswitch', 'cisco_apic_ml2'],
+                'tenant_network_types': ['vlan'],
+            }
+
         for opt, val in ml2_opts.items():
                 cfg.CONF.set_override(opt, val, 'ml2')
 

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -23,8 +23,6 @@ from apicapi import apic_client
 from apicapi import apic_manager
 from apicapi import apic_mapper
 import mock
-sys.modules["opflexagent"] = mock.Mock()
-sys.modules["opflexagent"].constants.TYPE_OPFLEX = 'opflex'
 import netaddr
 from neutron.api import extensions
 from neutron.common import constants as n_constants
@@ -34,12 +32,26 @@ from neutron.db import models_v2  # noqa
 from neutron.extensions import portbindings
 from neutron import manager
 from neutron.plugins.ml2 import db as ml2_db
+from neutron.plugins.ml2 import driver_api as api
 from neutron.plugins.ml2 import driver_context
 from neutron.plugins.ml2.drivers import type_vlan  # noqa
 from neutron.tests import base
 from neutron.tests.unit.api import test_extensions
 from neutron.tests.unit.db import test_db_base_plugin_v2 as test_plugin
+from opflexagent import constants as ofcst
 from oslo_serialization import jsonutils as json
+# Mock the opflex agent type driver, and its constants,
+# so that we can test port binding to opflex networks
+T_DRV = "opflexagent.type_opflex"
+sys.modules["opflexagent"] = mock.Mock()
+sys.modules["opflexagent"].constants.TYPE_OPFLEX = 'opflex'
+sys.modules["opflexagent"].constants.AGENT_TYPE_OPFLEX_OVS = (
+    'OpFlex Open vSwitch agent')
+sys.modules[T_DRV] = mock.Mock()
+sys.modules[T_DRV].OpflexTypeDriver().get_type.return_value = 'opflex'
+sys.modules[T_DRV].OpflexTypeDriver().allocate_tenant_segment.return_value = (
+    {api.NETWORK_TYPE: ofcst.TYPE_OPFLEX,
+     api.PHYSICAL_NETWORK: 'physnet1'})
 
 from apic_ml2.neutron.db import port_ha_ipaddress_binding as ha
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import (
@@ -71,6 +83,13 @@ AGENT_CONF = {'alive': True, 'binary': 'somebinary',
               'topic': 'sometopic', 'agent_type': AGENT_TYPE,
               'configurations': {'opflex_networks': None,
                                  'bridge_mappings': {'physnet1': 'br-eth1'}}}
+AGENT_TYPE_DVS = ofcst.AGENT_TYPE_OPFLEX_OVS
+AGENT_CONF_DVS = {'alive': True, 'binary': 'somebinary',
+                  'topic': 'sometopic', 'agent_type': AGENT_TYPE_DVS,
+                  'configurations':
+                      {'hypervisor_type': acst.HYPERVISOR_VCENTER,
+                       'opflex_networks': None,
+                       'bridge_mappings': {'physnet1': 'br-eth1'}}}
 
 
 def echo(context, id, prefix=''):
@@ -89,9 +108,9 @@ class ApicML2IntegratedTestBase(test_plugin.NeutronDbPluginV2TestCase,
                                 mocked.ControllerMixin, mocked.ConfigMixin,
                                 mocked.ApicDBTestBase):
 
-    def setUp(self, service_plugins=None):
+    def setUp(self, service_plugins=None, ml2_opts=None):
         mocked.ControllerMixin.set_up_mocks(self)
-        mocked.ConfigMixin.set_up_mocks(self)
+        mocked.ConfigMixin.set_up_mocks(self, ml2_opts=ml2_opts)
         self.override_conf('integrated_topology_service', True,
                            'ml2_cisco_apic')
         self.override_conf('per_tenant_context', False,
@@ -140,13 +159,25 @@ class ApicML2IntegratedTestBase(test_plugin.NeutronDbPluginV2TestCase,
             'dirtylittlesecret')
         self.driver.notifier = mock.Mock()
 
-    def _bind_port_to_host(self, port_id, host):
+    def _register_agent(self, host, agent_cfg=AGENT_CONF):
         plugin = manager.NeutronManager.get_plugin()
         ctx = context.get_admin_context()
         agent = {'host': host}
-        agent.update(AGENT_CONF)
+        agent.update(agent_cfg)
         plugin.create_or_update_agent(ctx, agent)
-        data = {'port': {'binding:host_id': host, 'device_owner': 'compute:',
+
+    def _bind_port_to_host(self, port_id, host):
+        data = {'port': {'binding:host_id': host,
+                         'device_owner': 'compute:nova',
+                         'device_id': 'someid'}}
+        # Create EP with bound port
+        req = self.new_update_request('ports', data, port_id,
+                                      self.fmt)
+        return self.deserialize(self.fmt, req.get_response(self.api))
+
+    def _bind_net_port_to_host(self, port_id, host):
+        data = {'port': {'binding:host_id': host,
+                         'device_owner': 'network:dhcp',
                          'device_id': 'someid'}}
         # Create EP with bound port
         req = self.new_update_request('ports', data, port_id,
@@ -211,6 +242,7 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
                           is_admin_context=True, expected_res_status=200)
 
     def test_port_on_shared_non_opflex_network(self):
+        self._register_agent('h1')
         net = self.create_network(
             tenant_id='onetenant', expected_res_status=201, shared=True,
             is_admin_context=True)['network']
@@ -231,6 +263,7 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
                     neutron_tenant='onetenant'))
 
     def test_port_on_shared_opflex_network(self):
+        self._register_agent('h1')
         net = self.create_network(
             tenant_id='onetenant', expected_res_status=201, shared=True,
             is_admin_context=True)['network']
@@ -255,6 +288,7 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
             self.assertEqual(sub['subnet']['id'], details['subnets'][0]['id'])
 
     def test_enhanced_subnet_options(self):
+        self._register_agent('h1')
         net = self.create_network(
             tenant_id='onetenant', expected_res_status=201, shared=True,
             is_admin_context=True)['network']
@@ -377,6 +411,7 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
         self.assertFalse(self.synchronizer._sync_base.called)
 
     def test_attestation(self):
+        self._register_agent('h1')
         net = self.create_network(
             tenant_id='onetenant', expected_res_status=201)['network']
         expected_attestation = {'ports': [{'switch': '102',
@@ -422,6 +457,7 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
             self.assertEqual(expected_mac, observed_mac)
 
     def test_dhcp_notifications_on_create(self):
+        self._register_agent('h1')
         net = self.create_network(
             expected_res_status=201, shared=True,
             is_admin_context=True)['network']
@@ -448,6 +484,7 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
                         self.driver.notifier.port_update.call_args_list)
 
     def test_dhcp_notifications_on_update(self):
+        self._register_agent('h1')
         net = self.create_network(
             expected_res_status=201, shared=True,
             is_admin_context=True)['network']
@@ -594,6 +631,8 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
             exp_calls, self.driver.notify_port_update.call_args_list)
 
     def test_gbp_details_for_allowed_address_pair(self):
+        self._register_agent('h1')
+        self._register_agent('h2')
         net = self.create_network(
             tenant_id=mocked.APIC_TENANT, expected_res_status=201)['network']
         sub1 = self.create_subnet(
@@ -769,6 +808,8 @@ class MechanismRpcTestCase(ApicML2IntegratedTestBase):
         self.assertIn(('h2', 'static'), peers)
 
     def test_remove_hostlink(self):
+        self._register_agent('h1')
+        self._register_agent('h2')
         # Test removal of one link
         self._add_hosts_to_apic(3)
         self.driver.apic_manager.delete_path = mock.Mock()
@@ -798,6 +839,7 @@ class MechanismRpcTestCase(ApicML2IntegratedTestBase):
                     0, self.driver.apic_manager.delete_path.call_count)
 
     def test_remove_hostlink_vpc(self):
+        self._register_agent('h1')
         self._add_hosts_to_apic(3, vpc=True)
         self.driver.apic_manager.delete_path = mock.Mock()
         net = self.create_network()['network']
@@ -824,6 +866,9 @@ class MechanismRpcTestCase(ApicML2IntegratedTestBase):
                                      '1'))
 
     def test_add_hostlink(self):
+        self._register_agent('h1')
+        self._register_agent('h2')
+        self._register_agent('rhel03')
         # Test removal of one link
         self._add_hosts_to_apic(2)
         net = self.create_network()['network']
@@ -862,6 +907,7 @@ class MechanismRpcTestCase(ApicML2IntegratedTestBase):
                             net['provider:segmentation_id']))
 
     def test_update_hostlink(self):
+        self._register_agent('h1')
         self._add_hosts_to_apic(1)
 
         net1 = self.create_network()['network']
@@ -1016,7 +1062,7 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
                                           'vm1', net_ctx, HOST_ID1,
                                           device_owner='any')
         mgr = self.driver.apic_manager
-        self.assertTrue(self.driver.check_segment_for_agent(
+        self.assertTrue(self.driver._check_segment_for_agent(
             port_ctx._bound_segment, self.agent))
         self.driver.create_port_postcommit(port_ctx)
         mgr.ensure_path_created_for_port.assert_called_once_with(
@@ -1032,7 +1078,7 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
                                           mocked.APIC_NETWORK,
                                           'vm1', net_ctx, HOST_ID1,
                                           device_owner='any')
-        self.assertTrue(self.driver.check_segment_for_agent(
+        self.assertTrue(self.driver._check_segment_for_agent(
             port_ctx._bound_segment, self.agent))
         mgr = self.driver.apic_manager
         self.driver.create_port_postcommit(port_ctx)
@@ -1907,6 +1953,152 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
             port['device_owner'] = n_constants.DEVICE_OWNER_ROUTER_GW
             port['device_id'] = mocked.APIC_ROUTER
         return FakePortContext(port, network_ctx)
+
+
+class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
+
+    def setUp(self, service_plugins=None):
+        ml2_opts = {
+            'mechanism_drivers': ['openvswitch', 'cisco_apic_ml2'],
+            'tenant_network_types': ['opflex'],
+            'type_drivers': ['opflex'],
+        }
+        super(ApicML2IntegratedTestCaseDvs, self).setUp(
+            service_plugins, ml2_opts=ml2_opts)
+        # This is required for the test. Without it,
+        # the ML2 driver's agent_type ends up being a
+        # mocked type, which fails when passed to the
+        # hast_agents() method for the PortContext
+        # (but only for types not defined by the
+        # mechanism driver class itself).
+        self.driver.agent_type = ofcst.AGENT_TYPE_OPFLEX_OVS
+
+    def test_bind_port_dvs(self):
+        # Register a DVS agent
+        self._register_agent('h1', agent_cfg=AGENT_CONF_DVS)
+        net = self.create_network(
+            tenant_id='onetenant', expected_res_status=201, shared=False,
+            is_admin_context=True)['network']
+        sub = self.create_subnet(
+            network_id=net['id'], cidr='192.168.0.0/24',
+            ip_version=4, is_admin_context=True)
+        with self.port(subnet=sub, tenant_id='onetenant') as p1:
+            p1 = p1['port']
+            self.assertEqual(net['id'], p1['network_id'])
+            self.mgr.ensure_path_created_for_port = mock.Mock()
+            # Bind port to trigger path binding
+            newp1 = self._bind_port_to_host(p1['id'], 'h1')
+            # Called on the network's tenant
+            expected_pg = (mocked.APIC_SYSTEM_ID + '|' +
+                           net['tenant_id'] + '|' + net['id'])
+            pg = newp1['port']['binding:vif_details']['dvs_port_group']
+            self.assertEqual(pg, expected_pg)
+
+    def test_bind_port_dvs_with_opflex_diff_hosts(self):
+        # Register an OpFlex agent and DVS agent
+        self._register_agent('h1')
+        self._register_agent('h2', agent_cfg=AGENT_CONF_DVS)
+        net = self.create_network(
+            tenant_id='onetenant', expected_res_status=201, shared=False,
+            is_admin_context=True)['network']
+        sub = self.create_subnet(
+            network_id=net['id'], cidr='192.168.0.0/24',
+            ip_version=4, is_admin_context=True)
+        # Bind a VLAN port after registering a DVS agent
+        with self.port(subnet=sub, tenant_id='onetenant') as p1:
+            p1 = p1['port']
+            self.assertEqual(net['id'], p1['network_id'])
+            self.mgr.ensure_path_created_for_port = mock.Mock()
+            # Bind port to trigger path binding
+            newp1 = self._bind_port_to_host(p1['id'], 'h2')
+            # Called on the network's tenant
+            expected_pg = (mocked.APIC_SYSTEM_ID + '|' +
+                           net['tenant_id'] + '|' + net['id'])
+            vif_det = newp1['port']['binding:vif_details']
+            self.assertIsNotNone(vif_det.get('dvs_port_group', None))
+            self.assertEqual(expected_pg, vif_det.get('dvs_port_group'))
+
+    def test_bind_ports_opflex_same_host(self):
+        # Register an OpFlex agent and DVS agent
+        self._register_agent('h1')
+        net = self.create_network(
+            tenant_id='onetenant', expected_res_status=201, shared=False,
+            is_admin_context=True)['network']
+        sub = self.create_subnet(
+            network_id=net['id'], cidr='192.168.0.0/24',
+            ip_version=4, is_admin_context=True)
+        # Bind a VLAN port after registering a DVS agent
+        with self.port(subnet=sub, tenant_id='onetenant') as p1:
+            p1 = p1['port']
+            self.assertEqual(net['id'], p1['network_id'])
+            self.mgr.ensure_path_created_for_port = mock.Mock()
+            # Bind port to trigger path binding
+            newp1 = self._bind_port_to_host(p1['id'], 'h1')
+            # Called on the network's tenant
+            vif_det = newp1['port']['binding:vif_details']
+            self.assertIsNone(vif_det.get('dvs_port_group', None))
+        with self.port(subnet=sub, tenant_id='onetenant') as p2:
+            p2 = p2['port']
+            self.assertEqual(net['id'], p2['network_id'])
+            self.mgr.ensure_path_created_for_port = mock.Mock()
+            # Bind port to trigger path binding
+            newp2 = self._bind_net_port_to_host(p2['id'], 'h1')
+            # Called on the network's tenant
+            vif_det = newp2['port']['binding:vif_details']
+            self.assertIsNone(vif_det.get('dvs_port_group', None))
+
+    def test_bind_ports_dvs_with_opflex_same_host(self):
+        # Register an OpFlex agent and DVS agent
+        self._register_agent('h1', agent_cfg=AGENT_CONF_DVS)
+        net = self.create_network(
+            tenant_id='onetenant', expected_res_status=201, shared=False,
+            is_admin_context=True)['network']
+        sub = self.create_subnet(
+            network_id=net['id'], cidr='192.168.0.0/24',
+            ip_version=4, is_admin_context=True)
+        # Bind a VLAN port after registering a DVS agent
+        with self.port(subnet=sub, tenant_id='onetenant') as p1:
+            p1 = p1['port']
+            self.assertEqual(net['id'], p1['network_id'])
+            self.mgr.ensure_path_created_for_port = mock.Mock()
+            # Bind port to trigger path binding
+            newp1 = self._bind_port_to_host(p1['id'], 'h1')
+            # Called on the network's tenant
+            expected_pg = (mocked.APIC_SYSTEM_ID + '|' +
+                           net['tenant_id'] + '|' + net['id'])
+            vif_det = newp1['port']['binding:vif_details']
+            self.assertIsNotNone(vif_det.get('dvs_port_group', None))
+            self.assertEqual(expected_pg, vif_det.get('dvs_port_group'))
+        with self.port(subnet=sub, tenant_id='onetenant') as p2:
+            p2 = p2['port']
+            self.assertEqual(net['id'], p2['network_id'])
+            self.mgr.ensure_path_created_for_port = mock.Mock()
+            # Bind port to trigger path binding
+            newp2 = self._bind_net_port_to_host(p2['id'], 'h1')
+            # Called on the network's tenant
+            vif_det = newp2['port']['binding:vif_details']
+            self.assertIsNone(vif_det.get('dvs_port_group', None))
+
+    def test_bind_port_dvs_shared(self):
+        # Register a DVS agent
+        self._register_agent('h1', agent_cfg=AGENT_CONF_DVS)
+        net = self.create_network(
+            tenant_id='onetenant', expected_res_status=201, shared=True,
+            is_admin_context=True)['network']
+        sub = self.create_subnet(
+            network_id=net['id'], cidr='192.168.0.0/24',
+            ip_version=4, is_admin_context=True)
+        with self.port(subnet=sub, tenant_id='onetenant') as p1:
+            p1 = p1['port']
+            self.assertEqual(net['id'], p1['network_id'])
+            self.mgr.ensure_path_created_for_port = mock.Mock()
+            # Bind port to trigger path binding
+            newp1 = self._bind_port_to_host(p1['id'], 'h1')
+            # Called on the network's tenant
+            expected_pg = (mocked.APIC_SYSTEM_ID + '|' +
+                           net['tenant_id'] + '|' + net['id'])
+            pg = newp1['port']['binding:vif_details']['dvs_port_group']
+            self.assertEqual(pg, expected_pg)
 
 
 class ApicML2IntegratedTestCaseSingleVRF(ApicML2IntegratedTestCase):


### PR DESCRIPTION
This adds support for port binding DVS VIF types. The
port group that the port belongs to is passed in the
VIF binding details, so that Nova can use it to bring
up teh instance.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
