### PR TITLE
Fix NAT machinery for some operational modes

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -306,7 +306,8 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
         external_networks = [x['id'] for x in networks if
                              x.get('router:external')]
         subnets = [x for x in subnets if
-                   x['network_id'] not in external_networks]
+                   (x['network_id'] not in external_networks and
+                    x['name'] != acst.HOST_SNAT_POOL)]
 
         if subnets:
             subnets = netaddr.IPSet([x['cidr'] for x in subnets])
@@ -315,13 +316,15 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
 
         vrf = self._get_tenant_vrf(vrf_id)
         details = {
-            'l3_policy_id': vrf_id,
             'vrf_tenant': self.apic_manager.apic.fvTenant.name(
                 vrf['aci_tenant']),
             'vrf_name': self.apic_manager.apic.fvCtx.name(
                 str(vrf['aci_name'])),
             'vrf_subnets': subnets
         }
+        details['l3_policy_id'] = (
+            self.per_tenant_context and vrf_id
+            or '%s-%s' % (details['vrf_tenant'], details['vrf_name']))
         return details
 
     # RPC Method
@@ -671,7 +674,7 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
             arouter_id = self.name_mapper.router(
                 context, router_id, openstack_owner=router['tenant_id'])
             cid = self.apic_manager.get_router_contract(
-                arouter_id, owner=vrf['aci_tenant'])
+                arouter_id, owner=self._get_router_aci_tenant(router))
             if self._is_pre_existing(router_info) and ('external_epg' in
                                                        router_info):
                 l3out_name_pre = self.name_mapper.pre_existing(
@@ -872,9 +875,10 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
                 context._binding.segment):
             self._delete_path_if_last(context)
         if port.get('device_owner') == n_constants.DEVICE_OWNER_ROUTER_GW:
-            self._delete_contract(context)
             if self._is_nat_enabled_on_ext_net(network):
                 self._delete_shadow_ext_net_for_nat(context, port, network)
+            else:
+                self._delete_contract(context)
         self._notify_ports_due_to_router_update(port)
 
     @sync_init
@@ -1072,14 +1076,22 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
 
     def _create_shadow_ext_net_for_nat(self, context, l3out_name, ext_epg_name,
                                        router_contract, network, router):
-        no_nat_vrf = self._get_tenant_vrf(router['tenant_id'])
+        vrf_info = self._get_tenant_vrf(router['tenant_id'])
         nat_epg_name = self._get_ext_epg_for_ext_net(l3out_name)
         shadow_ext_epg = self._get_shadow_name_for_nat(ext_epg_name)
-        shadow_l3out = self.name_mapper.l3_out(
-            context, network['id'],
-            openstack_owner=router['tenant_id'])
+        if self.per_tenant_context:
+            shadow_l3out = self.name_mapper.l3_out(
+                context, network['id'],
+                openstack_owner=router['tenant_id'])
+            router_tenant = self._get_tenant(router)
+        else:
+            # There is exactly one shadow L3Out for all tenants since there
+            # is exactly one VRF for all tenants
+            shadow_l3out = self.name_mapper.l3_out(context, network['id'])
+            router_tenant = vrf_info['aci_tenant']
+
         shadow_l3out = self._get_shadow_name_for_nat(shadow_l3out)
-        router_tenant = self._get_tenant(router)
+
         nat_epg_tenant = self._get_network_aci_tenant(network)
         net_info = self.apic_manager.ext_net_dict.get(network['name'])
         try:
@@ -1091,7 +1103,7 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
                 # network tenant
                 self.apic_manager.ensure_external_routed_network_created(
                     shadow_l3out, owner=router_tenant,
-                    context=no_nat_vrf['aci_name'], transaction=trs)
+                    context=vrf_info['aci_name'], transaction=trs)
                 self.apic_manager.ensure_external_epg_created(
                     shadow_l3out, external_epg=shadow_ext_epg,
                     owner=router_tenant, transaction=trs)
@@ -1102,7 +1114,8 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
                     address = net_info['cidr_exposed']
                     next_hop = net_info['gateway_ip']
                     vlan_id = self.l3out_vlan_alloc.reserve_vlan(
-                        network['name'], router['tenant_id'])
+                        network['name'], vrf_info['aci_name'],
+                        vrf_info['aci_tenant'])
                     switch = net_info['switch']
                     module, sport = net_info['port'].split('/')
 
@@ -1150,19 +1163,53 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
 
         router = self.l3_plugin.get_router(
             context._plugin_context, port.get('device_id'))
-        shadow_l3out = self.name_mapper.l3_out(
-            context, network['id'],
-            openstack_owner=router['tenant_id'])
-        # delete shadow L3-out and shadow external-EPG
-        shadow_l3out = self._get_shadow_name_for_nat(shadow_l3out)
-        self.apic_manager.delete_external_routed_network(
-            shadow_l3out, owner=self._get_network_aci_tenant(network))
+        vrf_info = self._get_tenant_vrf(router['tenant_id'])
+        remove_contracts_only = False
+        if self.per_tenant_context:
+            shadow_l3out = self.name_mapper.l3_out(
+                context, network['id'],
+                openstack_owner=router['tenant_id'])
+            router_tenant = self._get_tenant(router)
+        else:
+            shadow_l3out = self.name_mapper.l3_out(context, network['id'])
+            router_tenant = vrf_info['aci_tenant']
+            # if there are other routers still connected, only dissociate
+            # the contract for the router from shadow external EPG
+            router_gw_ports = context._plugin.get_ports(
+                context._plugin_context.elevated(),
+                filters={'device_owner': [n_constants.DEVICE_OWNER_ROUTER_GW],
+                         'network_id': [network['id']]})
+            remove_contracts_only = bool(
+                [p for p in router_gw_ports if p['id'] != port['id']])
 
-        # if there is a router_type (like ASR) then we have to release
-        # the vlan associated with this shadow L3out
-        if self._is_asr_router_type(ext_info):
-            self.l3out_vlan_alloc.release_vlan(
-                network['name'], router['tenant_id'])
+        shadow_l3out = self._get_shadow_name_for_nat(shadow_l3out)
+
+        if remove_contracts_only:
+            external_epg = apic_manager.EXT_EPG
+            arouter_id = self.name_mapper.router(
+                context, router['id'], openstack_owner=router['tenant_id'])
+            contract = self.apic_manager.get_router_contract(
+                arouter_id, owner=self._get_router_aci_tenant(router))
+            if self._is_pre_existing(ext_info) and 'external_epg' in ext_info:
+                external_epg = self.name_mapper.pre_existing(
+                    context, ext_info['external_epg'])
+            shadow_ext_epg = self._get_shadow_name_for_nat(external_epg)
+            self.apic_manager.unset_contract_for_external_epg(
+                shadow_l3out, contract, external_epg=shadow_ext_epg,
+                owner=router_tenant, provided=True)
+            self.apic_manager.unset_contract_for_external_epg(
+                shadow_l3out, contract, external_epg=shadow_ext_epg,
+                owner=router_tenant, provided=False)
+        else:
+            # delete shadow L3-out and shadow external-EPG
+            self.apic_manager.delete_external_routed_network(
+                shadow_l3out, owner=router_tenant)
+            # if there is a router_type (like ASR) then we have to release
+            # the vlan associated with this shadow L3out
+            if self._is_asr_router_type(ext_info):
+                self.l3out_vlan_alloc.release_vlan(
+                    network['name'], vrf_info['aci_name'],
+                    vrf_info['aci_tenant'])
 
     def _get_router_interface_subnets(self, context, router_ids):
         core_plugin = manager.NeutronManager.get_plugin()
@@ -1261,7 +1308,9 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
         vrf = {'aci_tenant': self.apic_system_id,
                'aci_name': self.name_mapper.tenant(None, tenant_id)}
         if not self.single_tenant_mode:
-            vrf['aci_tenant'] = self.name_mapper.tenant(None, tenant_id)
+            vrf['aci_tenant'] = (self.per_tenant_context and
+                                 self.name_mapper.tenant(None, tenant_id) or
+                                 apic_manager.TENANT_COMMON)
             vrf['aci_name'] = apic_manager.CONTEXT_SHARED
         elif not self.per_tenant_context:
             vrf['aci_name'] = apic_manager.CONTEXT_SHARED
@@ -1363,11 +1412,14 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
                     _("External Routed Network %s doesn't have private "
                       "network set") % l3out_name_pre)
                 return
-            l3out_tenant = l3out_info['l3out_tenant']
-            external_vrf = l3out_info['vrf_name']
-            external_vrf_tenant = l3out_info['vrf_tenant']
-            l3out_external_epg = net_info.get('external_epg',
-                                              apic_manager.EXT_EPG)
+            l3out_tenant = self.name_mapper.pre_existing(
+                context, l3out_info['l3out_tenant'])
+            external_vrf = self.name_mapper.pre_existing(
+                context, l3out_info['vrf_name'])
+            external_vrf_tenant = self.name_mapper.pre_existing(
+                context, l3out_info['vrf_tenant'])
+            l3out_external_epg = self.name_mapper.pre_existing(
+                context, net_info.get('external_epg', apic_manager.EXT_EPG))
         else:
             l3out_name_pre = None
             l3out_tenant = tenant_id
@@ -1515,9 +1567,10 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
                 LOG.error(
                     _("External Routed Network %s not found") % l3out_name_pre)
                 return
-            l3out_tenant = l3out_info['l3out_tenant']
-            l3out_external_epg = net_info.get('external_epg',
-                                              apic_manager.EXT_EPG)
+            l3out_tenant = self.name_mapper.pre_existing(
+                context, l3out_info['l3out_tenant'])
+            l3out_external_epg = self.name_mapper.pre_existing(
+                context, net_info.get('external_epg', apic_manager.EXT_EPG))
         else:
             l3out_name_pre = None
             l3out_tenant = tenant_id

--- a/apic_ml2/neutron/tests/unit/db/test_l3out_vlan_allocation.py
+++ b/apic_ml2/neutron/tests/unit/db/test_l3out_vlan_allocation.py
@@ -51,12 +51,14 @@ class L3outVlanAllocationTestCase(testlib_api.SqlTestCase):
             'Mgmt-Out']
         LOG.info(("vlan range: %d - %d"), vlan_min, vlan_max)
 
-        vlan_id1 = self.l3out_vlan_alloc.reserve_vlan('Mgmt-Out', 'admin')
+        vlan_id1 = self.l3out_vlan_alloc.reserve_vlan('Mgmt-Out', 'admin',
+                                                      'tenant1')
         LOG.info(("vlan reserved: %d"), vlan_id1)
         self.assertTrue(vlan_min <= vlan_id1 <= vlan_max)
 
         # it should reserve the same vlan with the same l3 network + vrf
-        vlan_id2 = self.l3out_vlan_alloc.reserve_vlan('Mgmt-Out', 'admin')
+        vlan_id2 = self.l3out_vlan_alloc.reserve_vlan('Mgmt-Out', 'admin',
+                                                      'tenant1')
         self.assertEqual(vlan_id1, vlan_id2)
 
         vlan_id3 = self.l3out_vlan_alloc.reserve_vlan('Mgmt-Out', 'demo')
@@ -64,22 +66,25 @@ class L3outVlanAllocationTestCase(testlib_api.SqlTestCase):
         self.assertTrue(vlan_min <= vlan_id3 <= vlan_max)
 
     def test_exception_thrown_reserve_vlan_when_full(self):
-        vlan_id1 = self.l3out_vlan_alloc.reserve_vlan('Mgmt-Out', 'test1')
-        vlan_id2 = self.l3out_vlan_alloc.reserve_vlan('Mgmt-Out', 'test2')
+        vlan_id1 = self.l3out_vlan_alloc.reserve_vlan('Mgmt-Out', 'test1',
+                                                      'tenant1')
+        vlan_id2 = self.l3out_vlan_alloc.reserve_vlan('Mgmt-Out', 'test2',
+                                                      'tenant1')
         self.assertNotEqual(vlan_id1, vlan_id2)
 
         self.assertRaises(l3out_vlan_alloc.NoVlanAvailable,
                           self.l3out_vlan_alloc.reserve_vlan,
-                          'Mgmt-Out', 'test3')
+                          'Mgmt-Out', 'test3', 'tenant1')
 
-        self.l3out_vlan_alloc.release_vlan('Mgmt-Out', 'test1')
-        vlan_id5 = self.l3out_vlan_alloc.reserve_vlan('Mgmt-Out', 'test3')
+        self.l3out_vlan_alloc.release_vlan('Mgmt-Out', 'test1', 'tenant1')
+        vlan_id5 = self.l3out_vlan_alloc.reserve_vlan('Mgmt-Out', 'test3',
+                                                      'tenant1')
         self.assertEqual(vlan_id1, vlan_id5)
 
         # test when the vlan pool is full again with different vrf
         self.assertRaises(l3out_vlan_alloc.NoVlanAvailable,
                           self.l3out_vlan_alloc.reserve_vlan,
-                          'Mgmt-Out', 'test1')
+                          'Mgmt-Out', 'test1', 'tenant1')
 
         # test when wrong L3 out network name
         self.assertRaises(l3out_vlan_alloc.NoVlanAvailable,
@@ -91,11 +96,12 @@ class L3outVlanAllocationTestCase(testlib_api.SqlTestCase):
         self.l3out_vlan_alloc.release_vlan('Mgmt-Out', 'garbage')
 
     def test_get_vlan_allocated(self):
-        vlan_id1 = self.l3out_vlan_alloc.reserve_vlan('Mgmt-Out', 'test')
+        vlan_id1 = self.l3out_vlan_alloc.reserve_vlan('Mgmt-Out', 'test',
+                                                      'tenant1')
         LOG.info(("vlan reserved: %d"), vlan_id1)
 
         vlan_id2 = l3out_vlan_alloc.L3outVlanAlloc.get_vlan_allocated(
-            'Mgmt-Out', 'test')
+            'Mgmt-Out', 'test', 'tenant1')
         LOG.info(("vlan allocated: %d"), vlan_id2)
         self.assertEqual(vlan_id1, vlan_id2)
 

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -29,7 +29,9 @@ import netaddr
 from neutron.api import extensions
 from neutron.common import constants as n_constants
 from neutron import context
+from neutron.db import api as db_api
 from neutron.db import db_base_plugin_v2  # noqa
+from neutron.db import model_base
 from neutron.db import models_v2  # noqa
 from neutron.extensions import portbindings
 from neutron import manager
@@ -923,6 +925,8 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
                               mocked.ControllerMixin,
                               mocked.ConfigMixin):
     def setUp(self):
+        model_base.BASEV2.metadata.create_all(db_api.get_engine())
+
         super(TestCiscoApicMechDriver, self).setUp()
         mocked.ControllerMixin.set_up_mocks(self)
         mocked.ConfigMixin.set_up_mocks(self)
@@ -933,6 +937,7 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         md.APICMechanismDriver.get_base_synchronizer = mock.Mock(
             return_value=self.synchronizer)
         md.APICMechanismDriver.get_apic_manager = mock.Mock()
+        apic_mapper.ApicName.__eq__ = equal
         self.driver.apic_manager = mock.Mock(
             name_mapper=mock.Mock(), ext_net_dict=self.external_network_dict)
         self.driver.initialize()
@@ -1092,40 +1097,43 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         self.driver.update_port_postcommit(port_ctx)
         mgr.get_router_contract.assert_called_once_with(
             self._scoped_name(port_ctx.current['device_id']),
-            owner=self._tenant(vrf=True))
+            owner=self._router_tenant())
 
+        shd_l3out = (self.driver.per_tenant_context and
+                     self._scoped_name(mocked.APIC_NETWORK) or
+                     mocked.APIC_NETWORK)
         expected_calls = [
-            mock.call("Shd-%s" % self._scoped_name(mocked.APIC_NETWORK),
-                      owner=self._tenant(), transaction=mock.ANY,
+            mock.call("Shd-%s" % shd_l3out,
+                      owner=self._tenant(ext_nat=True), transaction=mock.ANY,
                       context=self._network_vrf_name())]
         self._check_call_list(
             expected_calls,
             mgr.ensure_external_routed_network_created.call_args_list)
 
         expected_calls = [
-            mock.call("Shd-%s" % self._scoped_name(mocked.APIC_NETWORK),
+            mock.call("Shd-%s" % shd_l3out,
                       external_epg="Shd-%s" % mocked.APIC_EXT_EPG,
-                      owner=self._tenant(), transaction=mock.ANY)]
+                      owner=self._tenant(ext_nat=True), transaction=mock.ANY)]
 
         self._check_call_list(
             expected_calls, mgr.ensure_external_epg_created.call_args_list)
 
         expected_calls = [
             mock.call(
-                "Shd-%s" % self._scoped_name(mocked.APIC_NETWORK),
+                "Shd-%s" % shd_l3out,
                 mgr.get_router_contract.return_value,
                 external_epg="Shd-%s" % mocked.APIC_EXT_EPG,
-                owner=self._tenant(), transaction=mock.ANY)]
+                owner=self._tenant(ext_nat=True), transaction=mock.ANY)]
         self._check_call_list(
             expected_calls,
             mgr.ensure_external_epg_consumed_contract.call_args_list)
 
         expected_calls = [
             mock.call(
-                "Shd-%s" % self._scoped_name(mocked.APIC_NETWORK),
+                "Shd-%s" % shd_l3out,
                 mgr.get_router_contract.return_value,
                 external_epg="Shd-%s" % mocked.APIC_EXT_EPG,
-                owner=self._tenant(), transaction=mock.ANY)]
+                owner=self._tenant(ext_nat=True), transaction=mock.ANY)]
         self._check_call_list(
             expected_calls,
             mgr.ensure_external_epg_provided_contract.call_args_list)
@@ -1146,48 +1154,52 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         mgr = self.driver.apic_manager
         mgr.get_router_contract.return_value = mocked.FakeDbContract(
             mocked.APIC_CONTRACT)
+        self.driver.l3out_vlan_alloc.reserve_vlan = mock.Mock()
         self.driver.update_port_postcommit(port_ctx)
         mgr.get_router_contract.assert_called_once_with(
             self._scoped_name(port_ctx.current['device_id']),
-            owner=self._tenant(vrf=True))
+            owner=self._router_tenant())
 
+        shd_l3out = (self.driver.per_tenant_context and
+                     self._scoped_name(mocked.APIC_NETWORK_ASR) or
+                     mocked.APIC_NETWORK_ASR)
         expected_calls = [
-            mock.call("Shd-%s" % self._scoped_name(mocked.APIC_NETWORK_ASR),
-                      owner=self._tenant(), transaction=mock.ANY,
+            mock.call("Shd-%s" % shd_l3out,
+                      owner=self._tenant(ext_nat=True), transaction=mock.ANY,
                       context=self._network_vrf_name())]
         self._check_call_list(
             expected_calls,
             mgr.ensure_external_routed_network_created.call_args_list)
 
         expected_calls = [
-            mock.call("Shd-%s" % self._scoped_name(mocked.APIC_NETWORK_ASR),
+            mock.call("Shd-%s" % shd_l3out,
                       external_epg="Shd-%s" % mocked.APIC_EXT_EPG,
-                      owner=self._tenant(), transaction=mock.ANY)]
+                      owner=self._tenant(ext_nat=True), transaction=mock.ANY)]
 
         self._check_call_list(
             expected_calls, mgr.ensure_external_epg_created.call_args_list)
 
-        self.assertTrue(self.driver.l3out_vlan_alloc.reserve_vlan)
+        self.assertTrue(self.driver.l3out_vlan_alloc.reserve_vlan.called)
         self.assertTrue(mgr.set_domain_for_external_routed_network.called)
         self.assertTrue(mgr.ensure_logical_node_profile_created.called)
         self.assertTrue(mgr.ensure_static_route_created.called)
 
         expected_calls = [
             mock.call(
-                "Shd-%s" % self._scoped_name(mocked.APIC_NETWORK_ASR),
+                "Shd-%s" % shd_l3out,
                 mgr.get_router_contract.return_value,
                 external_epg="Shd-%s" % mocked.APIC_EXT_EPG,
-                owner=self._tenant(), transaction=mock.ANY)]
+                owner=self._tenant(ext_nat=True), transaction=mock.ANY)]
         self._check_call_list(
             expected_calls,
             mgr.ensure_external_epg_consumed_contract.call_args_list)
 
         expected_calls = [
             mock.call(
-                "Shd-%s" % self._scoped_name(mocked.APIC_NETWORK_ASR),
+                "Shd-%s" % shd_l3out,
                 mgr.get_router_contract.return_value,
                 external_epg="Shd-%s" % mocked.APIC_EXT_EPG,
-                owner=self._tenant(), transaction=mock.ANY)]
+                owner=self._tenant(ext_nat=True), transaction=mock.ANY)]
         self._check_call_list(
             expected_calls,
             mgr.ensure_external_epg_provided_contract.call_args_list)
@@ -1211,11 +1223,14 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         self.driver.update_port_postcommit(port_ctx)
         mgr.get_router_contract.assert_called_once_with(
             self._scoped_name(port_ctx.current['device_id']),
-            owner=self._tenant(vrf=True))
+            owner=self._router_tenant())
 
+        shd_l3out = (self.driver.per_tenant_context and
+                     self._scoped_name(mocked.APIC_NETWORK_PRE) or
+                     mocked.APIC_NETWORK_PRE)
         expected_calls = [
-            mock.call("Shd-%s" % self._scoped_name(mocked.APIC_NETWORK_PRE),
-                      owner=self._tenant(), transaction=mock.ANY,
+            mock.call("Shd-%s" % shd_l3out,
+                      owner=self._tenant(ext_nat=True), transaction=mock.ANY,
                       context=self._network_vrf_name())]
         self._check_call_list(
             expected_calls,
@@ -1226,29 +1241,29 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         self.assertFalse(mgr.ensure_static_route_created.called)
 
         mgr.ensure_external_epg_created.assert_called_once_with(
-            "Shd-%s" % self._scoped_name(mocked.APIC_NETWORK_PRE),
+            "Shd-%s" % shd_l3out,
             external_epg="Shd-%s" % self._scoped_name(mocked.APIC_EXT_EPG,
                                                       preexisting=True),
-            owner=self._tenant(), transaction=mock.ANY)
+            owner=self._tenant(ext_nat=True), transaction=mock.ANY)
 
         expected_calls = [
             mock.call(
-                "Shd-%s" % self._scoped_name(mocked.APIC_NETWORK_PRE),
+                "Shd-%s" % shd_l3out,
                 mgr.get_router_contract.return_value,
                 external_epg="Shd-%s" % self._scoped_name(mocked.APIC_EXT_EPG,
                                                           preexisting=True),
-                owner=self._tenant(), transaction=mock.ANY)]
+                owner=self._tenant(ext_nat=True), transaction=mock.ANY)]
         self._check_call_list(
             expected_calls,
             mgr.ensure_external_epg_consumed_contract.call_args_list)
 
         expected_calls = [
             mock.call(
-                "Shd-%s" % self._scoped_name(mocked.APIC_NETWORK_PRE),
+                "Shd-%s" % shd_l3out,
                 mgr.get_router_contract.return_value,
                 external_epg="Shd-%s" % self._scoped_name(mocked.APIC_EXT_EPG,
                                                           preexisting=True),
-                owner=self._tenant(), transaction=mock.ANY)]
+                owner=self._tenant(ext_nat=True), transaction=mock.ANY)]
         self._check_call_list(
             expected_calls,
             mgr.ensure_external_epg_provided_contract.call_args_list)
@@ -1281,7 +1296,7 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         self.driver.update_port_postcommit(port_ctx)
         mgr.get_router_contract.assert_called_once_with(
             self._scoped_name(port_ctx.current['device_id']),
-            owner=self._tenant(vrf=True))
+            owner=self._router_tenant())
 
         self.assertFalse(mgr.ensure_external_routed_network_created.called)
         self.assertFalse(mgr.ensure_external_epg_created.called)
@@ -1332,12 +1347,11 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         self.driver._delete_path_if_last = mock.Mock()
         self.driver.delete_port_postcommit(port_ctx)
         mgr = self.driver.apic_manager
-        mgr.delete_external_epg_contract.assert_called_once_with(
-            self._scoped_name(mocked.APIC_ROUTER),
-            self._scoped_name(mocked.APIC_NETWORK))
         mgr.delete_external_routed_network.assert_called_once_with(
-            "Shd-%s" % self._scoped_name(mocked.APIC_NETWORK),
-            owner=self._tenant())
+            "Shd-%s" % (self.driver.per_tenant_context and
+                        self._scoped_name(mocked.APIC_NETWORK) or
+                        mocked.APIC_NETWORK),
+            owner=self._tenant(ext_nat=True))
 
     def test_delete_asr_gw_port_postcommit(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,
@@ -1347,12 +1361,15 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
                                           mocked.APIC_NETWORK_ASR,
                                           'vm1', net_ctx, HOST_ID1, gw=True)
         self.driver._delete_path_if_last = mock.Mock()
+        self.driver.l3out_vlan_alloc.release_vlan = mock.Mock()
         self.driver.delete_port_postcommit(port_ctx)
         mgr = self.driver.apic_manager
         mgr.delete_external_routed_network.assert_called_once_with(
-            "Shd-%s" % self._scoped_name(mocked.APIC_NETWORK_ASR),
-            owner=self._tenant())
-        self.assertTrue(self.driver.l3out_vlan_alloc.release_vlan)
+            "Shd-%s" % (self.driver.per_tenant_context and
+                        self._scoped_name(mocked.APIC_NETWORK_ASR) or
+                        mocked.APIC_NETWORK_ASR),
+            owner=self._tenant(ext_nat=True))
+        self.assertTrue(self.driver.l3out_vlan_alloc.release_vlan.called)
 
     def test_update_no_nat_gw_port_postcommit(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,
@@ -1368,7 +1385,7 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         self.driver.update_port_postcommit(port_ctx)
         mgr.get_router_contract.assert_called_once_with(
             self._scoped_name(port_ctx.current['device_id']),
-            owner=self._tenant(vrf=True))
+            owner=self._router_tenant())
 
         mgr.ensure_external_epg_consumed_contract.assert_called_once_with(
             self._scoped_name(mocked.APIC_NETWORK_NO_NAT),
@@ -1425,21 +1442,11 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         self.driver._query_l3out_info.return_value = {
             'l3out_tenant': 'bar_tenant'}
         self.driver.delete_port_postcommit(port_ctx)
-        contract_name = "contract-%s" % mocked.APIC_ROUTER
-        l3out = self._scoped_name(net_ctx.current['name'], preexisting=True)
-        expected_calls = [
-            mock.call(l3out, contract_name,
-                      external_epg=mocked.APIC_EXT_EPG, provided=True,
-                      owner='bar_tenant'),
-            mock.call(l3out, contract_name,
-                      external_epg=mocked.APIC_EXT_EPG, provided=False,
-                      owner='bar_tenant')]
-        self._check_call_list(
-            expected_calls,
-            mgr.unset_contract_for_external_epg.call_args_list)
         mgr.delete_external_routed_network.assert_called_once_with(
-            "Shd-%s" % self._scoped_name(mocked.APIC_NETWORK_PRE),
-            owner=self._tenant())
+            "Shd-%s" % (self.driver.per_tenant_context and
+                        self._scoped_name(mocked.APIC_NETWORK_PRE) or
+                        mocked.APIC_NETWORK_PRE),
+            owner=self._tenant(ext_nat=True))
 
     def test_create_network_postcommit(self):
         ctx = self._get_network_context(mocked.APIC_TENANT,
@@ -1967,12 +1974,63 @@ class ApicML2IntegratedTestCaseNoSingleTenantSingleContext(
               self).setUp(service_plugins)
 
 
-class TestCiscoApicMechDriverPerTenantVRF(TestCiscoApicMechDriver):
+class TestCiscoApicMechDriverSingleVRF(TestCiscoApicMechDriver):
 
     def setUp(self):
-        self.override_conf('per_tenant_context', True,
+        self.override_conf('per_tenant_context', False,
                            'ml2_cisco_apic')
-        super(TestCiscoApicMechDriverPerTenantVRF, self).setUp()
+        super(TestCiscoApicMechDriverSingleVRF, self).setUp()
+
+    def _test_delete_gw_port_multiple_postcommit(self, pre):
+        if pre:
+            ext_net_name = mocked.APIC_NETWORK_PRE
+            ext_epg = self._scoped_name(mocked.APIC_EXT_EPG,
+                                        preexisting=True)
+        else:
+            ext_net_name = mocked.APIC_NETWORK
+            ext_epg = mocked.APIC_EXT_EPG
+        net_ctx = self._get_network_context(mocked.APIC_TENANT,
+                                            ext_net_name,
+                                            TEST_SEGMENT1, external=True)
+        port_ctx1 = self._get_port_context(mocked.APIC_TENANT,
+                                           ext_net_name,
+                                           'gw', net_ctx, HOST_ID1, gw=True)
+        port_ctx2 = self._get_port_context(mocked.APIC_TENANT,
+                                           ext_net_name,
+                                           'gw', net_ctx, HOST_ID1, gw=True)
+        port_ctx2.current['id'] += 1
+        port_ctx1._plugin.get_ports.return_value = [port_ctx1.current,
+                                                    port_ctx2.current]
+        self.driver._delete_path_if_last = mock.Mock()
+        mgr = self.driver.apic_manager
+        mgr.get_router_contract.return_value = mocked.FakeDbContract(
+            mocked.APIC_CONTRACT)
+
+        self.driver.delete_port_postcommit(port_ctx1)
+        self.assertFalse(mgr.delete_external_routed_network.called)
+        exp_calls = [
+            mock.call("Shd-%s" % ext_net_name,
+                      mgr.get_router_contract.return_value,
+                      external_epg="Shd-%s" % ext_epg,
+                      owner=self._tenant(ext_nat=True), provided=True),
+            mock.call("Shd-%s" % ext_net_name,
+                      mgr.get_router_contract.return_value,
+                      external_epg="Shd-%s" % ext_epg,
+                      owner=self._tenant(ext_nat=True), provided=False)
+        ]
+        self._check_call_list(
+            exp_calls, mgr.unset_contract_for_external_epg.call_args_list)
+
+        port_ctx2._plugin.get_ports.return_value = [port_ctx2.current]
+        self.driver.delete_port_postcommit(port_ctx2)
+        mgr.delete_external_routed_network.assert_called_once_with(
+            "Shd-%s" % ext_net_name, owner=self._tenant(ext_nat=True))
+
+    def test_delete_gw_port_multiple_postcommit(self):
+        self._test_delete_gw_port_multiple_postcommit(pre=False)
+
+    def test_delete_pre_gw_port_multiple_postcommit(self):
+        self._test_delete_gw_port_multiple_postcommit(pre=True)
 
 
 class TestCiscoApicMechDriverMultiTenant(TestCiscoApicMechDriver):
@@ -1983,13 +2041,13 @@ class TestCiscoApicMechDriverMultiTenant(TestCiscoApicMechDriver):
         super(TestCiscoApicMechDriverMultiTenant, self).setUp()
 
 
-class TestCiscoApicMechDriverMultiTenantPerTenantVRF(
-        TestCiscoApicMechDriverPerTenantVRF):
+class TestCiscoApicMechDriverMultiTenantSingleVRF(
+        TestCiscoApicMechDriverSingleVRF):
 
     def setUp(self):
         self.override_conf('single_tenant_mode', False,
                            'ml2_cisco_apic')
-        super(TestCiscoApicMechDriverMultiTenantPerTenantVRF, self).setUp()
+        super(TestCiscoApicMechDriverMultiTenantSingleVRF, self).setUp()
 
 
 class TestCiscoApicMechDriverHostSNAT(ApicML2IntegratedTestBase):


### PR DESCRIPTION
In the multi-tenant mode, fix the tenant and scoping of
ACI object.
In single VRF mode:
- create only one shadow L3out irrespective of number of
  tenants as there is only one VRF in ACI
- 'l3_policy_id' in get_vrf_details() returns the same
  value for all tenants
- If router-type is ASR, only one VLAN gets allocated.
  Modified the vlan allocation code to use name and tenant
  of ACI VRF that is created.

Signed-off-by: Amit Bose bose@noironetworks.com
