### PR TITLE
Don't include availability zone for device_owner

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -206,7 +206,7 @@ class APICMechanismDriver(mech_agent.AgentMechanismDriverBase,
            us it's supporting a VMware hypervisor.
         """
         port = context.current
-        if port['device_owner'] == 'compute:nova':
+        if port['device_owner'].startswith('compute:'):
             hv_type = agent['configurations'].get('hypervisor_type', None)
             if hv_type and hv_type == acst.HYPERVISOR_VCENTER:
                 return True

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -170,7 +170,7 @@ class ApicML2IntegratedTestBase(test_plugin.NeutronDbPluginV2TestCase,
 
     def _bind_port_to_host(self, port_id, host):
         data = {'port': {'binding:host_id': host,
-                         'device_owner': 'compute:nova',
+                         'device_owner': 'compute:',
                          'device_id': 'someid'}}
         # Create EP with bound port
         req = self.new_update_request('ports', data, port_id,


### PR DESCRIPTION
The current code looks for compute:nova. This is wrong, as the "nova"
postfix is the availability zone, which we can't depend on. This patch
changes it to just look for the "compute:" prefix.

Closes Issue: #46
Signed-off-by: Thomas Bachman tbachman@yahoo.com
