### PR TITLE
Added DVS VIF type support.

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/constants.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/constants.py
@@ -13,12 +13,12 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+# TODO(tbachman) Figure out a better/common place for this
+AGENT_TYPE_DVS = 'DVS agent'
 APIC_SYNC_NETWORK = 'apic-sync-network'
 HOST_SNAT_NETWORK_PREFIX = 'host-snat-network-for-internal-use-'
 HOST_SNAT_POOL = 'host-snat-pool-for-internal-use'
 HOST_SNAT_POOL_PORT = 'host-snat-pool-port-for-internal-use'
-# TODO(tbachman) Figure out a better/common place for this
-HYPERVISOR_VCENTER = "VMware vCenter"
 DEVICE_OWNER_SNAT_PORT = 'host-snat-pool-port-device-owner-internal-use'
 # TODO(tbachman) figure out a better/common place for this
 VIF_TYPE_DVS = "dvs"


### PR DESCRIPTION
This modifies the mechanism driver to support port
binding for DVS VIF types. Since mechanism drivers
qualify port binding by only binding for hosts that
are running a matching agent, it adds a constraint
that an OpFlex agent and DVS agent can only exist
on the same host when the OpFlex agent is used for
network services, such as dhcp and metadata agents,
and not compute services (otherwise, binding of ports
for compute would be ambiguous).

NB: This patch essentially reverts commit
bbfa030e55f56a8c06e165890d2b8d974085cae1.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
