### PR TITLE
Add RPCs for DVS agent

### DIFF
--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -79,6 +79,8 @@ SUBNET_NETMASK = '24'
 TEST_SEGMENT1 = 'test-segment1'
 TEST_SEGMENT2 = 'test-segment2'
 
+BOOKED_PORT_VALUE = 'myBookedPort'
+
 PLUGIN_NAME = 'neutron.plugins.ml2.plugin.Ml2Plugin'
 AGENT_TYPE = n_constants.AGENT_TYPE_OVS
 AGENT_CONF = {'alive': True, 'binary': 'somebinary',
@@ -2017,6 +2019,24 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
         # (but only for types not defined by the
         # mechanism driver class itself).
         self.driver.agent_type = ofcst.AGENT_TYPE_OPFLEX_OVS
+        self.driver.dvs_notifier = mock.MagicMock()
+        self.driver.dvs_notifier.bind_port_call = mock.Mock(
+            return_value=BOOKED_PORT_VALUE)
+
+    def _verify_dvs_notifier(self, notifier, port, host):
+            # can't use getattr() with mock, so use eval instead
+            try:
+                dvs_mock = eval('self.driver.dvs_notifier.' + notifier)
+            except Exception:
+                self.assertTrue(False,
+                                "The method " + notifier + " was not called")
+                return
+
+            self.assertTrue(dvs_mock.called)
+            a1, a2, a3, a4 = dvs_mock.call_args[0]
+            self.assertEqual(a1['id'], port['id'])
+            self.assertEqual(a2['id'], port['id'])
+            self.assertEqual(a4, host)
 
     def test_bind_port_dvs(self):
         # Register a DVS agent
@@ -2038,6 +2058,14 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
                            net['tenant_id'] + '|' + net['id'])
             pg = newp1['port']['binding:vif_details']['dvs_port_group']
             self.assertEqual(pg, expected_pg)
+            port_key = newp1['port']['binding:vif_details'].get('dvs_port_key')
+            self.assertIsNotNone(port_key)
+            self.assertEqual(port_key, BOOKED_PORT_VALUE)
+            self._verify_dvs_notifier('update_postcommit_port_call', p1, 'h1')
+            net_ctx = FakeNetworkContext(net, [mock.Mock()])
+            port_ctx = FakePortContext(newp1['port'], net_ctx)
+            self.driver.delete_port_postcommit(port_ctx)
+            self._verify_dvs_notifier('delete_port_call', p1, 'h1')
 
     def test_bind_port_dvs_with_opflex_diff_hosts(self):
         # Register an OpFlex agent and DVS agent
@@ -2062,6 +2090,14 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             vif_det = newp1['port']['binding:vif_details']
             self.assertIsNotNone(vif_det.get('dvs_port_group', None))
             self.assertEqual(expected_pg, vif_det.get('dvs_port_group'))
+            port_key = newp1['port']['binding:vif_details'].get('dvs_port_key')
+            self.assertIsNotNone(port_key)
+            self.assertEqual(port_key, BOOKED_PORT_VALUE)
+            self._verify_dvs_notifier('update_postcommit_port_call', p1, 'h2')
+            net_ctx = FakeNetworkContext(net, [mock.Mock()])
+            port_ctx = FakePortContext(newp1['port'], net_ctx)
+            self.driver.delete_port_postcommit(port_ctx)
+            self._verify_dvs_notifier('delete_port_call', p1, 'h2')
 
     def test_bind_ports_opflex_same_host(self):
         # Register an OpFlex agent and DVS agent
@@ -2082,6 +2118,16 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             # Called on the network's tenant
             vif_det = newp1['port']['binding:vif_details']
             self.assertIsNone(vif_det.get('dvs_port_group', None))
+            port_key = newp1['port']['binding:vif_details'].get('dvs_port_key')
+            self.assertIsNone(port_key)
+            dvs_mock = self.driver.dvs_notifier.update_postcommit_port_call
+            dvs_mock.assert_not_called()
+            net_ctx = FakeNetworkContext(net, [mock.Mock()])
+            port_ctx = FakePortContext(newp1['port'], net_ctx)
+            self.driver.delete_port_postcommit(port_ctx)
+            dvs_mock = self.driver.dvs_notifier.delete_port_call
+            dvs_mock.assert_not_called()
+        self.driver.dvs_notifier.reset_mock()
         with self.port(subnet=sub, tenant_id='onetenant') as p2:
             p2 = p2['port']
             self.assertEqual(net['id'], p2['network_id'])
@@ -2091,6 +2137,14 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             # Called on the network's tenant
             vif_det = newp2['port']['binding:vif_details']
             self.assertIsNone(vif_det.get('dvs_port_group', None))
+            port_key = newp2['port']['binding:vif_details'].get('dvs_port_key')
+            self.assertIsNone(port_key)
+            dvs_mock.assert_not_called()
+            net_ctx = FakeNetworkContext(net, [mock.Mock()])
+            port_ctx = FakePortContext(newp2['port'], net_ctx)
+            self.driver.delete_port_postcommit(port_ctx)
+            dvs_mock = self.driver.dvs_notifier.delete_port_call
+            dvs_mock.assert_not_called()
 
     def test_bind_ports_dvs_with_opflex_same_host(self):
         # Register an OpFlex agent and DVS agent
@@ -2114,6 +2168,15 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             vif_det = newp1['port']['binding:vif_details']
             self.assertIsNotNone(vif_det.get('dvs_port_group', None))
             self.assertEqual(expected_pg, vif_det.get('dvs_port_group'))
+            port_key = newp1['port']['binding:vif_details'].get('dvs_port_key')
+            self.assertIsNotNone(port_key)
+            self.assertEqual(port_key, BOOKED_PORT_VALUE)
+            self._verify_dvs_notifier('update_postcommit_port_call', p1, 'h1')
+            net_ctx = FakeNetworkContext(net, [mock.Mock()])
+            port_ctx = FakePortContext(newp1['port'], net_ctx)
+            self.driver.delete_port_postcommit(port_ctx)
+            self._verify_dvs_notifier('delete_port_call', p1, 'h1')
+        self.driver.dvs_notifier.reset_mock()
         with self.port(subnet=sub, tenant_id='onetenant') as p2:
             p2 = p2['port']
             self.assertEqual(net['id'], p2['network_id'])
@@ -2123,6 +2186,15 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             # Called on the network's tenant
             vif_det = newp2['port']['binding:vif_details']
             self.assertIsNone(vif_det.get('dvs_port_group', None))
+            port_key = newp2['port']['binding:vif_details'].get('dvs_port_key')
+            self.assertIsNone(port_key)
+            dvs_mock = self.driver.dvs_notifier.update_postcommit_port_call
+            dvs_mock.assert_not_called()
+            net_ctx = FakeNetworkContext(net, [mock.Mock()])
+            port_ctx = FakePortContext(newp2['port'], net_ctx)
+            self.driver.delete_port_postcommit(port_ctx)
+            dvs_mock = self.driver.dvs_notifier.delete_port_call
+            dvs_mock.assert_not_called()
 
     def test_bind_port_dvs_shared(self):
         # Register a DVS agent
@@ -2144,6 +2216,14 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
                            net['tenant_id'] + '|' + net['id'])
             pg = newp1['port']['binding:vif_details']['dvs_port_group']
             self.assertEqual(pg, expected_pg)
+            port_key = newp1['port']['binding:vif_details'].get('dvs_port_key')
+            self.assertIsNotNone(port_key)
+            self.assertEqual(port_key, BOOKED_PORT_VALUE)
+            self._verify_dvs_notifier('update_postcommit_port_call', p1, 'h1')
+            net_ctx = FakeNetworkContext(net, [mock.Mock()])
+            port_ctx = FakePortContext(newp1['port'], net_ctx)
+            self.driver.delete_port_postcommit(port_ctx)
+            self._verify_dvs_notifier('delete_port_call', p1, 'h1')
 
 
 class ApicML2IntegratedTestCaseSingleVRF(ApicML2IntegratedTestCase):
@@ -2541,6 +2621,7 @@ class FakePortContext(object):
             self._bound_segment = None
 
         self.current = self._port
+        self.original = self._port
         self.network = self._network
         self.top_bound_segment = self._bound_segment
         self.host = self._port.get(portbindings.HOST_ID)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 
 -e git+https://github.com/noironetworks/apicapi.git@master#egg=apicapi
 -e git+https://github.com/noironetworks/python-opflex-agent.git@master#egg=python-opflexagent-agent
+-e git+https://github.com/Mirantis/vmware-dvs.git@master#egg=vmware_dvs


### PR DESCRIPTION
The DVS agent creates ports in the DVS. This requires
RPCs in the mechanism driver in order to provide the
DVS to neutron port mapping/association, as well as
maintain overall port state in the agent.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
