### PR TITLE
Remove explicit import of DVS agent

### DIFF
--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -139,6 +139,7 @@ class ApicML2IntegratedTestBase(test_plugin.NeutronDbPluginV2TestCase,
         self.driver = self.plugin.mechanism_manager.mech_drivers[
             'cisco_apic_ml2'].obj
         self.synchronizer = mock.Mock()
+        md.importutils = mock.Mock()
         md.APICMechanismDriver.get_base_synchronizer = mock.Mock(
             return_value=self.synchronizer)
         self.driver.name_mapper.aci_mapper.tenant = echo
@@ -2019,7 +2020,7 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
         # (but only for types not defined by the
         # mechanism driver class itself).
         self.driver.agent_type = ofcst.AGENT_TYPE_OPFLEX_OVS
-        self.driver.dvs_notifier = mock.MagicMock()
+        self.driver._dvs_notifier = mock.MagicMock()
         self.driver.dvs_notifier.bind_port_call = mock.Mock(
             return_value=BOOKED_PORT_VALUE)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@
 
 -e git+https://github.com/noironetworks/apicapi.git@master#egg=apicapi
 -e git+https://github.com/noironetworks/python-opflex-agent.git@master#egg=python-opflexagent-agent
--e git+https://github.com/Mirantis/vmware-dvs.git@master#egg=vmware_dvs


### PR DESCRIPTION
The explicit import of the DVS agent makes having
this package installed a requirement. This patch
changes the explicit import to a lazy-loaded import.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
