### PR TITLE
Fix build breakage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@
 
 -e git+https://github.com/noironetworks/apicapi.git@master#egg=apicapi
 -e git+https://github.com/noironetworks/python-opflex-agent.git@master#egg=python-opflexagent-agent
+
+# These are needed until the 2.3 Routes is excluded in upstream dependencies
+Routes!=2.0,!=2.1,!=2.3,>=1.12.3;python_version=='2.7' # MIT
+Routes!=2.0,!=2.3,>=1.12.3;python_version!='2.7' # MIT


### PR DESCRIPTION
The recent change of Routes from 2.2.0 to 2.3.0
broke the build. This patch adds Routes 2.2.0
or less to the test requirements.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
