### PR TITLE
Update DVS key name

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -270,10 +270,11 @@ class APICMechanismDriver(api.MechanismDriver,
             project_name = self.name_mapper.tenant(None, net['tenant_id'])
             # Use default security groups from MD
             vif_details = {portbindings.CAP_PORT_FILTER: self.sg_enabled}
-            vif_details['dvs_port_group'] = (cfg.CONF.apic_system_id +
-                                             '|' + str(project_name) +
-                                             '|' + str(network_name))
-            context.current['portgroup_name'] = vif_details['dvs_port_group']
+            vif_details['dvs_port_group_name'] = (cfg.CONF.apic_system_id +
+                                                  '|' + str(project_name) +
+                                                  '|' + str(network_name))
+            context.current['portgroup_name'] = (
+                vif_details['dvs_port_group_name'])
             if self.dvs_notifier:
                 booked_port_key = self.dvs_notifier.bind_port_call(
                     context.current,
@@ -957,7 +958,7 @@ class APICMechanismDriver(api.MechanismDriver,
         self._perform_port_operations(context)
         port = context.current
         if (port.get('binding:vif_details') and
-                port['binding:vif_details'].get('dvs_port_group')) and (
+                port['binding:vif_details'].get('dvs_port_group_name')) and (
                 self.dvs_notifier):
             self.dvs_notifier.update_postcommit_port_call(
                 context.current,
@@ -990,7 +991,7 @@ class APICMechanismDriver(api.MechanismDriver,
                 self._delete_contract(context)
         self._notify_ports_due_to_router_update(port)
         if (port.get('binding:vif_details') and
-                port['binding:vif_details'].get('dvs_port_group')) and (
+                port['binding:vif_details'].get('dvs_port_group_name')) and (
                 self.dvs_notifier):
             self.dvs_notifier.delete_port_call(
                 context.current,

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -2057,7 +2057,7 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             # Called on the network's tenant
             expected_pg = (mocked.APIC_SYSTEM_ID + '|' +
                            net['tenant_id'] + '|' + net['id'])
-            pg = newp1['port']['binding:vif_details']['dvs_port_group']
+            pg = newp1['port']['binding:vif_details']['dvs_port_group_name']
             self.assertEqual(pg, expected_pg)
             port_key = newp1['port']['binding:vif_details'].get('dvs_port_key')
             self.assertIsNotNone(port_key)
@@ -2089,8 +2089,8 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             expected_pg = (mocked.APIC_SYSTEM_ID + '|' +
                            net['tenant_id'] + '|' + net['id'])
             vif_det = newp1['port']['binding:vif_details']
-            self.assertIsNotNone(vif_det.get('dvs_port_group', None))
-            self.assertEqual(expected_pg, vif_det.get('dvs_port_group'))
+            self.assertIsNotNone(vif_det.get('dvs_port_group_name', None))
+            self.assertEqual(expected_pg, vif_det.get('dvs_port_group_name'))
             port_key = newp1['port']['binding:vif_details'].get('dvs_port_key')
             self.assertIsNotNone(port_key)
             self.assertEqual(port_key, BOOKED_PORT_VALUE)
@@ -2118,7 +2118,7 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             newp1 = self._bind_port_to_host(p1['id'], 'h1')
             # Called on the network's tenant
             vif_det = newp1['port']['binding:vif_details']
-            self.assertIsNone(vif_det.get('dvs_port_group', None))
+            self.assertIsNone(vif_det.get('dvs_port_group_name', None))
             port_key = newp1['port']['binding:vif_details'].get('dvs_port_key')
             self.assertIsNone(port_key)
             dvs_mock = self.driver.dvs_notifier.update_postcommit_port_call
@@ -2137,7 +2137,7 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             newp2 = self._bind_dhcp_port_to_host(p2['id'], 'h1')
             # Called on the network's tenant
             vif_det = newp2['port']['binding:vif_details']
-            self.assertIsNone(vif_det.get('dvs_port_group', None))
+            self.assertIsNone(vif_det.get('dvs_port_group_name', None))
             port_key = newp2['port']['binding:vif_details'].get('dvs_port_key')
             self.assertIsNone(port_key)
             dvs_mock.assert_not_called()
@@ -2167,8 +2167,8 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             expected_pg = (mocked.APIC_SYSTEM_ID + '|' +
                            net['tenant_id'] + '|' + net['id'])
             vif_det = newp1['port']['binding:vif_details']
-            self.assertIsNotNone(vif_det.get('dvs_port_group', None))
-            self.assertEqual(expected_pg, vif_det.get('dvs_port_group'))
+            self.assertIsNotNone(vif_det.get('dvs_port_group_name', None))
+            self.assertEqual(expected_pg, vif_det.get('dvs_port_group_name'))
             port_key = newp1['port']['binding:vif_details'].get('dvs_port_key')
             self.assertIsNotNone(port_key)
             self.assertEqual(port_key, BOOKED_PORT_VALUE)
@@ -2186,7 +2186,7 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             newp2 = self._bind_dhcp_port_to_host(p2['id'], 'h1')
             # Called on the network's tenant
             vif_det = newp2['port']['binding:vif_details']
-            self.assertIsNone(vif_det.get('dvs_port_group', None))
+            self.assertIsNone(vif_det.get('dvs_port_group_name', None))
             port_key = newp2['port']['binding:vif_details'].get('dvs_port_key')
             self.assertIsNone(port_key)
             dvs_mock = self.driver.dvs_notifier.update_postcommit_port_call
@@ -2215,7 +2215,7 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             # Called on the network's tenant
             expected_pg = (mocked.APIC_SYSTEM_ID + '|' +
                            net['tenant_id'] + '|' + net['id'])
-            pg = newp1['port']['binding:vif_details']['dvs_port_group']
+            pg = newp1['port']['binding:vif_details']['dvs_port_group_name']
             self.assertEqual(pg, expected_pg)
             port_key = newp1['port']['binding:vif_details'].get('dvs_port_key')
             self.assertIsNotNone(port_key)


### PR DESCRIPTION
A patch to upstream Nova added the DVS port group
paramaters to the VIF binding details. This patch
uses the same key name as the one used in the upstream
patch.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
