### PR TITLE
Ignore empty-tenant routers

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -770,6 +770,11 @@ class APICMechanismDriver(api.MechanismDriver,
         network_tenant = self._get_network_aci_tenant(network)
         router = self.l3_plugin.get_router(context._plugin_context, router_id)
 
+        # Other L3 plugins (e.g. ASR) create db-only routers, which
+        # are indicated by an empty string tenant. Don't do anything
+        # for these devices
+        if router['tenant_id'] == '':
+            return
         vrf = self._get_tenant_vrf(router['tenant_id'])
         if router_id and router_info:
             external_epg = apic_manager.EXT_EPG
@@ -831,6 +836,12 @@ class APICMechanismDriver(api.MechanismDriver,
         network = context.network.current
         ext_info = self.apic_manager.ext_net_dict.get(network['name'])
         router = self.l3_plugin.get_router(context._plugin_context, router_id)
+
+        # Other L3 plugins (e.g. ASR) create db-only routers, which
+        # are indicated by an empty string tenant. Don't do anything
+        # for these devices
+        if router['tenant_id'] == '':
+            return
         vrf_info = self._get_tenant_vrf(router['tenant_id'])
         if router_id and ext_info:
             nat_reqd = self._is_nat_required(
@@ -856,6 +867,12 @@ class APICMechanismDriver(api.MechanismDriver,
             openstack_owner=network['tenant_id'])
         router = self.l3_plugin.get_router(
             context._plugin_context, port.get('device_id'))
+
+        # Other L3 plugins (e.g. ASR) create db-only routers, which
+        # are indicated by an empty string tenant. Don't do anything
+        # for these devices
+        if router['tenant_id'] == '':
+            return
         arouter_id = self.name_mapper.router(
             context, port.get('device_id'),
             openstack_owner=router['tenant_id'])
@@ -1283,6 +1300,11 @@ class APICMechanismDriver(api.MechanismDriver,
         vrf_info = self._get_tenant_vrf(router['tenant_id'])
         remove_contracts_only = False
 
+        # Other L3 plugins (e.g. ASR) create db-only routers, which
+        # are indicated by an empty string tenant. Don't do anything
+        # for these devices
+        if router['tenant_id'] == '':
+            return
         # Determine all router-gateway ports on this external network
         gw_port_filter = {
             'device_owner': [n_constants.DEVICE_OWNER_ROUTER_GW],

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -1118,6 +1118,45 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         self.driver.create_port_postcommit(port_ctx)
         mgr.ensure_path_created_for_port.assert_not_called()
 
+    def test_create_port_precommit_empty_tenant(self):
+        self.driver._is_nat_enabled_on_ext_net = mock.Mock(return_value=True)
+        self.driver._l3_plugin.get_router = mock.Mock(
+            return_value={'id': mocked.APIC_ROUTER, 'tenant_id': ''})
+        net_ctx = self._get_network_context(mocked.APIC_TENANT,
+                                            mocked.APIC_NETWORK,
+                                            TEST_SEGMENT1,
+                                            seg_type=ofcst.TYPE_OPFLEX)
+        r_cnst = n_constants.DEVICE_OWNER_ROUTER_GW
+        port_ctx = self._get_port_context(mocked.APIC_TENANT,
+                                          mocked.APIC_NETWORK,
+                                          mocked.APIC_ROUTER,
+                                          net_ctx, HOST_ID1,
+                                          device_owner=r_cnst)
+        self.assertTrue(self.driver._check_segment_for_agent(
+            port_ctx._bound_segment, self.agent))
+        self.driver.create_port_precommit(port_ctx)
+        self.driver._is_nat_enabled_on_ext_net.assert_not_called()
+
+    def test_create_port_postcommit_empty_tenant(self):
+        self.driver._create_shadow_ext_net_for_nat = mock.Mock()
+        self.driver._is_nat_enabled_on_ext_net = mock.Mock(return_value=True)
+        self.driver._l3_plugin.get_router = mock.Mock(
+            return_value={'id': mocked.APIC_ROUTER, 'tenant_id': ''})
+        net_ctx = self._get_network_context(mocked.APIC_TENANT,
+                                            mocked.APIC_NETWORK,
+                                            TEST_SEGMENT1,
+                                            seg_type=ofcst.TYPE_OPFLEX)
+        r_cnst = n_constants.DEVICE_OWNER_ROUTER_GW
+        port_ctx = self._get_port_context(mocked.APIC_TENANT,
+                                          mocked.APIC_NETWORK,
+                                          mocked.APIC_ROUTER,
+                                          net_ctx, HOST_ID1,
+                                          device_owner=r_cnst)
+        self.assertTrue(self.driver._check_segment_for_agent(
+            port_ctx._bound_segment, self.agent))
+        self.driver.create_port_postcommit(port_ctx)
+        self.driver._create_shadow_ext_net_for_nat.assert_not_called()
+
     def test_create_port_postcommit_opflex(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,
                                             mocked.APIC_NETWORK,
@@ -1441,6 +1480,22 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
                         self._scoped_name(mocked.APIC_NETWORK) or
                         mocked.APIC_NETWORK),
             owner=self._tenant(ext_nat=True))
+
+    def test_delete_gw_port_postcommit_empty_tenant(self):
+        self.driver._l3_plugin.get_router = mock.Mock(
+            return_value={'id': mocked.APIC_ROUTER, 'tenant_id': ''})
+        net_ctx = self._get_network_context(mocked.APIC_TENANT,
+                                            mocked.APIC_NETWORK,
+                                            TEST_SEGMENT1, external=True)
+        r_cnst = n_constants.DEVICE_OWNER_ROUTER_GW
+        port_ctx = self._get_port_context(mocked.APIC_TENANT,
+                                          mocked.APIC_NETWORK,
+                                          mocked.APIC_ROUTER,
+                                          net_ctx, HOST_ID1, gw=True,
+                                          device_owner=r_cnst)
+        self.driver.delete_port_postcommit(port_ctx)
+        mgr = self.driver.apic_manager
+        mgr.delete_external_routed_network.assert_not_called()
 
     def test_delete_asr_gw_port_postcommit(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,


### PR DESCRIPTION
Some Layer 3 plugins create routers with an
empty string for the tenant_id (this follows
a convention used in neutron -- for example,
router gateway ports). These routers aren't
meant to create behaviors in APIC, so calls
with empty tenant routers should be No-Ops.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
