### PR TITLE
port the preexisting support from gbp to ml2

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -14,6 +14,7 @@
 #    under the License.
 
 import copy
+import re
 
 from apicapi import apic_manager
 from apicapi import apic_mapper
@@ -45,6 +46,7 @@ from opflexagent import rpc as o_rpc
 from oslo_concurrency import lockutils
 from oslo_config import cfg
 from oslo_log import log as logging
+from oslo_serialization import jsonutils
 from oslo_utils import importutils
 
 from apic_ml2.neutron.db import l3out_vlan_allocation as l3out_vlan_alloc
@@ -505,7 +507,7 @@ class APICMechanismDriver(api.MechanismDriver,
         owned_addr = self.ha_ip_handler.get_ha_ipaddresses_for_port(port['id'])
 
         ext_info = self.apic_manager.ext_net_dict.get(network['name'])
-        if ext_info and self._is_asr_router_type(ext_info):
+        if ext_info and self._is_edge_nat(ext_info):
             pass
         else:
             self._add_ip_mapping_details(context, port, kwargs['host'],
@@ -1285,14 +1287,115 @@ class APICMechanismDriver(api.MechanismDriver,
     def _get_nat_vrf_for_ext_net(self, l3out_name):
         return "NAT-vrf-%s" % l3out_name
 
-    def _get_shadow_name_for_nat(self, name):
-        return "Shd-%s" % name
+    def _get_shadow_name_for_nat(self, name, is_edge_nat=False):
+        if is_edge_nat:
+            return "Auto-%s" % name
+        else:
+            return "Shd-%s" % name
 
     def _get_ext_allow_all_contract(self, network):
         return "EXT-%s-allow-all" % network['id']
 
     def _get_snat_db_network_name(self, network):
         return acst.HOST_SNAT_NETWORK_PREFIX + network['id']
+
+    # return True if key exists in req_dict
+    def _trim_tDn_from_dict(self, req_dict, key):
+        try:
+            if req_dict.get(key) is not None:
+                del req_dict['tDn']
+                return True
+            else:
+                return False
+        except KeyError:
+            return True
+
+    def _trim_keys_from_dict(self, req_dict, keys, encap, l3p_name):
+        for key in keys:
+            try:
+                del req_dict[key]
+            except KeyError:
+                pass
+
+        # remove the default value parameter and replace encap
+        if (req_dict.get('targetDscp') and
+                req_dict['targetDscp'] == 'unspecified'):
+            del req_dict['targetDscp']
+        if req_dict.get('addr') and req_dict['addr'] == '0.0.0.0':
+            del req_dict['addr']
+        if req_dict.get('encap'):
+            if req_dict['encap'] == 'unknown':
+                del req_dict['encap']
+            elif req_dict['encap'].startswith('vlan-'):
+                req_dict['encap'] = encap
+
+        # this is for l3extRsEctx case that it
+        # doesn't allow tDn being present
+        if self._trim_tDn_from_dict(req_dict, 'tnFvCtxName'):
+            req_dict['tnFvCtxName'] = l3p_name
+        # this is for l3extRsNdIfPol case
+        self._trim_tDn_from_dict(req_dict, 'tnNdIfPolName')
+        # this is for l3extRsDampeningPol/l3extRsInterleakPol case
+        self._trim_tDn_from_dict(req_dict, 'tnRtctrlProfileName')
+        # this is for ospfRsIfPol case
+        self._trim_tDn_from_dict(req_dict, 'tnOspfIfPolName')
+        # this is for l3extRs[I|E]ngressQosDppPol case
+        self._trim_tDn_from_dict(req_dict, 'tnQosDppPolName')
+        # this is for bfdRsIfPol case
+        self._trim_tDn_from_dict(req_dict, 'tnBfdIfPolName')
+        # this is for bgpRsPeerPfxPol case
+        self._trim_tDn_from_dict(req_dict, 'tnBgpPeerPfxPolName')
+        # this is for eigrpRsIfPol case
+        self._trim_tDn_from_dict(req_dict, 'tnEigrpIfPolName')
+
+        for value in req_dict.values():
+            if isinstance(value, dict):
+                self._trim_keys_from_dict(value, keys, encap, l3p_name)
+            elif isinstance(value, list):
+                for element in value:
+                    if isinstance(element, dict):
+                        self._trim_keys_from_dict(element, keys,
+                                                  encap, l3p_name)
+        return req_dict
+
+    def _clone_l3out(self, context, network_tenant, router_tenant, vrf, es,
+                     es_name, encap):
+        pre_es_name = self.name_mapper.pre_existing(context, es['name'])
+        l3out_info = self._query_l3out_info(pre_es_name, network_tenant,
+                                            return_full=True)
+
+        old_tenant = self.apic_manager.apic.fvTenant.rn(
+            l3out_info['l3out_tenant'])
+        new_tenant = self.apic_manager.apic.fvTenant.rn(router_tenant)
+        old_l3_out = self.apic_manager.apic.l3extOut.rn(pre_es_name)
+        new_l3_out = self.apic_manager.apic.l3extOut.rn(es_name)
+
+        request = {}
+        request['children'] = l3out_info['l3out']
+        request['attributes'] = {"rn": new_l3_out}
+
+        # trim the request
+        keys = (['l3extInstP', 'l3extRtBDToOut',
+                 'l3extExtEncapAllocator',
+                 'l3extRsOutToBDPublicSubnetHolder', 'modTs',
+                 'uid', 'lcOwn', 'monPolDn', 'forceResolve',
+                 'rType', 'state', 'stateQual', 'tCl', 'tType',
+                 'type', 'tContextDn', 'tRn', 'tag', 'name',
+                 'configIssues'])
+        request = self._trim_keys_from_dict(request, keys, encap, vrf)
+        final_req = {}
+        final_req['l3extOut'] = request
+        request_json = jsonutils.dumps(final_req)
+        if old_tenant != new_tenant:
+            request_json = re.sub(old_tenant, new_tenant, request_json)
+        request_json = re.sub(old_l3_out, new_l3_out, request_json)
+        request_json = re.sub('{},*', '', request_json)
+
+        self.apic_manager.apic.post_body(
+            self.apic_manager.apic.l3extOut.mo,
+            request_json,
+            router_tenant,
+            es_name)
 
     def _create_shadow_ext_net_for_nat(self, context, l3out_name, ext_epg_name,
                                        router_contract, network, router):
@@ -1310,10 +1413,11 @@ class APICMechanismDriver(api.MechanismDriver,
             shadow_l3out = self.name_mapper.l3_out(context, network['id'])
             router_tenant = vrf_info['aci_tenant']
 
-        shadow_l3out = self._get_shadow_name_for_nat(shadow_l3out)
+        net_info = self.apic_manager.ext_net_dict.get(network['name'])
+        shadow_l3out = self._get_shadow_name_for_nat(
+            shadow_l3out, self._is_edge_nat(net_info))
 
         nat_epg_tenant = self._get_network_aci_tenant(network)
-        net_info = self.apic_manager.ext_net_dict.get(network['name'])
         try:
             with self.apic_manager.apic.transaction(None) as trs:
                 # create shadow L3-out and shadow external-epg
@@ -1321,34 +1425,52 @@ class APICMechanismDriver(api.MechanismDriver,
                 # Note: Only NAT l3Out may exist in a different tenant
                 # (eg. COMMON). NO NAT L3Outs always exists in the original
                 # network tenant
-                self.apic_manager.ensure_external_routed_network_created(
-                    shadow_l3out, owner=router_tenant,
-                    context=vrf_info['aci_name'], transaction=trs)
+
+                # don't need to explicitly create the shadow l3out in this case
+                # because we are going to query APIC then use the pre-existing
+                # l3out as a template then clone it accordingly
+                if (self._is_edge_nat(net_info) and
+                        self._is_pre_existing(net_info)):
+                    pass
+                else:
+                    self.apic_manager.ensure_external_routed_network_created(
+                        shadow_l3out, owner=router_tenant,
+                        context=vrf_info['aci_name'], transaction=trs)
+
+                # if its edge nat then we have to flesh
+                # out this shadow L3 out in APIC
+                if self._is_edge_nat(net_info):
+                    vlan_id = self.l3out_vlan_alloc.reserve_vlan(
+                        network['name'], str(vrf_info['aci_name']),
+                        router_tenant)
+                    encap = 'vlan-' + str(vlan_id)
+                    if not self._is_pre_existing(net_info):
+                        address = net_info['cidr_exposed']
+                        next_hop = net_info['gateway_ip']
+                        switch = net_info['switch']
+                        module, sport = net_info['port'].split('/')
+
+                        (self.apic_manager.
+                            set_domain_for_external_routed_network(
+                                shadow_l3out, owner=router_tenant,
+                                transaction=trs))
+                        self.apic_manager.ensure_logical_node_profile_created(
+                            shadow_l3out, switch, module, sport,
+                            encap, address, transaction=trs,
+                            owner=router_tenant)
+                        self.apic_manager.ensure_static_route_created(
+                            shadow_l3out, switch, next_hop,
+                            owner=router_tenant,
+                            transaction=trs)
+                    else:
+                        self._clone_l3out(context, str(nat_epg_tenant),
+                                          str(router_tenant),
+                                          str(vrf_info['aci_name']), network,
+                                          shadow_l3out, encap)
+
                 self.apic_manager.ensure_external_epg_created(
                     shadow_l3out, external_epg=shadow_ext_epg,
                     owner=router_tenant, transaction=trs)
-
-                # if there is a router_type (like ASR) then we have to flesh
-                # out this shadow L3 out in APIC
-                if self._is_asr_router_type(net_info):
-                    address = net_info['cidr_exposed']
-                    next_hop = net_info['gateway_ip']
-                    vlan_id = self.l3out_vlan_alloc.reserve_vlan(
-                        network['name'], vrf_info['aci_name'],
-                        vrf_info['aci_tenant'])
-                    switch = net_info['switch']
-                    module, sport = net_info['port'].split('/')
-
-                    self.apic_manager.set_domain_for_external_routed_network(
-                        shadow_l3out, owner=router_tenant, transaction=trs)
-                    self.apic_manager.ensure_logical_node_profile_created(
-                        shadow_l3out, switch, module, sport,
-                        'vlan-' + str(vlan_id), address, transaction=trs,
-                        owner=router_tenant)
-                    self.apic_manager.ensure_static_route_created(
-                        shadow_l3out, switch, next_hop,
-                        owner=router_tenant,
-                        transaction=trs)
 
                 # make them use router-contract
                 self.apic_manager.ensure_external_epg_consumed_contract(
@@ -1361,10 +1483,7 @@ class APICMechanismDriver(api.MechanismDriver,
                     owner=router_tenant, transaction=trs)
 
                 # link up shadow external-EPG to NAT EPG
-
-                # ASR is the only router we support now so any other values
-                # we treat it as none
-                if not self._is_asr_router_type(net_info):
+                if not self._is_edge_nat(net_info):
                     self.apic_manager.associate_external_epg_to_nat_epg(
                         router_tenant, shadow_l3out, shadow_ext_epg,
                         nat_epg_name, target_owner=nat_epg_tenant,
@@ -1403,7 +1522,8 @@ class APICMechanismDriver(api.MechanismDriver,
         remove_contracts_only = (
             not self._is_last_gw_port(context, port, router))
 
-        shadow_l3out = self._get_shadow_name_for_nat(shadow_l3out)
+        shadow_l3out = self._get_shadow_name_for_nat(
+            shadow_l3out, self._is_edge_nat(ext_info))
 
         if remove_contracts_only:
             external_epg = apic_manager.EXT_EPG
@@ -1425,9 +1545,9 @@ class APICMechanismDriver(api.MechanismDriver,
             # delete shadow L3-out and shadow external-EPG
             self.apic_manager.delete_external_routed_network(
                 shadow_l3out, owner=router_tenant)
-            # if there is a router_type (like ASR) then we have to release
+            # if its edge nat then we have to release
             # the vlan associated with this shadow L3out
-            if self._is_asr_router_type(ext_info):
+            if self._is_edge_nat(ext_info):
                 self.l3out_vlan_alloc.release_vlan(
                     network['name'], vrf_info['aci_name'],
                     vrf_info['aci_tenant'])
@@ -1840,7 +1960,7 @@ class APICMechanismDriver(api.MechanismDriver,
         self._delete_snat_ip_allocation_network(
             context._plugin_context, network)
 
-    def _query_l3out_info(self, l3out_name, tenant_id):
+    def _query_l3out_info(self, l3out_name, tenant_id, return_full=False):
         info = {'l3out_tenant': tenant_id}
         l3out_children = self.apic_manager.apic.l3extOut.get_subtree(
             info['l3out_tenant'], l3out_name)
@@ -1860,15 +1980,17 @@ class APICMechanismDriver(api.MechanismDriver,
                     info['vrf_tenant'] = ctx_dn[1][3:]
                 if ctx_dn[2].startswith('ctx-'):
                     info['vrf_name'] = ctx_dn[2][4:]
+        if return_full:
+            info['l3out'] = l3out_children
         return info
 
     def _is_pre_existing(self, ext_info):
         opt = ext_info.get('preexisting', 'false')
         return opt.lower() in ['true', 'yes', '1']
 
-    def _is_asr_router_type(self, ext_info):
-        router_type = ext_info.get('router_type', 'none')
-        return router_type.lower() == 'asr'
+    def _is_edge_nat(self, ext_info):
+        opt = ext_info.get('edge_nat', 'false')
+        return opt.lower() in ['true', 'yes', '1']
 
     def _is_last_gw_port(self, context, gw_port, router):
         gw_port_filter = {

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_common.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_common.py
@@ -38,7 +38,8 @@ APIC_NETWORK = 'network99'
 APIC_NETWORK_PRE = 'network_pre'
 APIC_NETWORK_NO_NAT = 'network_no_nat'
 APIC_NETWORK_HOST_SNAT = 'network-host-snat'
-APIC_NETWORK_ASR = 'network_asr'
+APIC_NETWORK_EDGE_NAT = 'network_edge_nat'
+APIC_NETWORK_PRE_EDGE_NAT = 'network_pre_edge_nat'
 APIC_EXT_EPG = 'external_epg'
 APIC_NETNAME = 'net99name'
 APIC_SUBNET = '10.3.2.1/24'
@@ -318,13 +319,19 @@ class ConfigMixin(object):
                 'gateway_ip': APIC_EXT_GATEWAY_IP,
                 'host_pool_cidr': HOST_POOL_CIDR,
             },
-            APIC_NETWORK_ASR + '-name': {
-                'router_type': 'ASR',
+            APIC_NETWORK_EDGE_NAT + '-name': {
+                'edge_nat': 'True',
                 'switch': APIC_EXT_SWITCH,
                 'port': APIC_EXT_MODULE + '/' + APIC_EXT_PORT,
                 'cidr_exposed': APIC_EXT_CIDR_EXPOSED,
                 'gateway_ip': APIC_EXT_GATEWAY_IP,
                 'vlan_range': '1600:1610'
+            },
+            APIC_NETWORK_PRE_EDGE_NAT + '-name': {
+                'preexisting': 'True',
+                'external_epg': APIC_EXT_EPG,
+                'edge_nat': 'true',
+                'vlan_range': '1700:1710'
             },
         }
 

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -16,6 +16,7 @@
 import base64
 import hashlib
 import hmac
+import re
 import sys
 import tempfile
 
@@ -1053,11 +1054,21 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
 
         def get_resource(context, resource_id):
             return {'id': resource_id, 'tenant_id': mocked.APIC_TENANT}
-
         self.driver._l3_plugin.get_router = get_resource
-
         self.driver._l3_plugin.get_routers = mock.Mock(return_value=[
             {'id': mocked.APIC_ROUTER, 'tenant_id': mocked.APIC_TENANT}])
+
+        self.trimmed_l3out = u'{"l3extOut": {"attributes": {"rn": "Auto-Sub\
+"}, "children": [    {"l3extRsNdIfPol": {"tnNdIfPolName": ""}}, \
+{"l3extRsDampeningPol": {"tnRtctrlProfileName": ""}}, {"ospfRsIfPol": \
+{"tnOspfIfPolName": ""}}, {"l3extRsEngressQosDppPol": {"tnQosDppPolName": ""}}\
+, {"bfdRsIfPol": {"tnBfdIfPolName": ""}}, {"bgpRsPeerPfxPol": \
+{"tnBgpPeerPfxPolName": ""}}, {"eigrpRsIfPol": {"tnEigrpIfPolName": ""}}, \
+{"l3extLNodeP": {"attributes": {"dn": "uni/tn-Sub/out-Auto-Sub/\
+lnodep-Leaf3-4_NP"}, "children": [{"l3extLIfP": {"children": [{"\
+l3extRsPathL3OutAtt": {"attributes": {"ifInstT": "sub-interface", "encap": \
+"vlan-999"}}}]}}]}}, {"l3extRsEctx": {"attributes": {"dn": "uni/tn-Sub\
+/out-Auto-Sub/rsectx", "tnFvCtxName": "ctx-Sub"}}}]}}'
 
     def _check_call_list(self, expected, observed):
         exp_bkp = expected[:]
@@ -1272,12 +1283,13 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
     def test_update_cross_tenant_gw_port_postcommit(self):
         self._test_update_gw_port_postcommit('admin_tenant')
 
-    def test_update_asr_gw_port_postcommit(self):
-        net_ctx = self._get_network_context(mocked.APIC_TENANT,
-                                            mocked.APIC_NETWORK_ASR,
+    def _test_update_edge_nat_gw_port_postcommit(
+        self, net_tenant=mocked.APIC_TENANT):
+        net_ctx = self._get_network_context(net_tenant,
+                                            mocked.APIC_NETWORK_EDGE_NAT,
                                             TEST_SEGMENT1, external=True)
         port_ctx = self._get_port_context(mocked.APIC_TENANT,
-                                          mocked.APIC_NETWORK_ASR,
+                                          mocked.APIC_NETWORK_EDGE_NAT,
                                           'vm1', net_ctx, HOST_ID1, gw=True)
         mgr = self.driver.apic_manager
         mgr.get_router_contract.return_value = mocked.FakeDbContract(
@@ -1288,11 +1300,12 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
             self._scoped_name(port_ctx.current['device_id']),
             owner=self._router_tenant())
 
-        shd_l3out = (self.driver.per_tenant_context and
-                     self._scoped_name(mocked.APIC_NETWORK_ASR) or
-                     mocked.APIC_NETWORK_ASR)
+        l3out_name = (self.driver.per_tenant_context and
+                      self._scoped_name(mocked.APIC_NETWORK_EDGE_NAT) or
+                      mocked.APIC_NETWORK_EDGE_NAT)
+        l3out_name = "Auto-%s" % l3out_name
         expected_calls = [
-            mock.call("Shd-%s" % shd_l3out,
+            mock.call(l3out_name,
                       owner=self._tenant(ext_nat=True), transaction=mock.ANY,
                       context=self._network_vrf_name())]
         self._check_call_list(
@@ -1300,21 +1313,22 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
             mgr.ensure_external_routed_network_created.call_args_list)
 
         expected_calls = [
-            mock.call("Shd-%s" % shd_l3out,
+            mock.call(l3out_name,
                       external_epg="Shd-%s" % mocked.APIC_EXT_EPG,
                       owner=self._tenant(ext_nat=True), transaction=mock.ANY)]
-
         self._check_call_list(
             expected_calls, mgr.ensure_external_epg_created.call_args_list)
 
-        self.assertTrue(self.driver.l3out_vlan_alloc.reserve_vlan.called)
+        self.driver.l3out_vlan_alloc.reserve_vlan.assert_called_once_with(
+            mocked.APIC_NETWORK_EDGE_NAT + '-name', self._network_vrf_name(),
+            self._tenant(ext_nat=True))
         self.assertTrue(mgr.set_domain_for_external_routed_network.called)
         self.assertTrue(mgr.ensure_logical_node_profile_created.called)
         self.assertTrue(mgr.ensure_static_route_created.called)
 
         expected_calls = [
             mock.call(
-                "Shd-%s" % shd_l3out,
+                l3out_name,
                 mgr.get_router_contract.return_value,
                 external_epg="Shd-%s" % mocked.APIC_EXT_EPG,
                 owner=self._tenant(ext_nat=True), transaction=mock.ANY)]
@@ -1324,13 +1338,158 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
 
         expected_calls = [
             mock.call(
-                "Shd-%s" % shd_l3out,
+                l3out_name,
                 mgr.get_router_contract.return_value,
                 external_epg="Shd-%s" % mocked.APIC_EXT_EPG,
                 owner=self._tenant(ext_nat=True), transaction=mock.ANY)]
         self._check_call_list(
             expected_calls,
             mgr.ensure_external_epg_provided_contract.call_args_list)
+
+    def test_update_edge_nat_gw_port_postcommit(self):
+        self._test_update_edge_nat_gw_port_postcommit()
+
+    def test_update_cross_tenant_edge_nat_gw_port_postcommit(self):
+        self._test_update_edge_nat_gw_port_postcommit('admin_tenant')
+
+    def _test_update_pre_edge_nat_gw_port_postcommit(
+        self, net_tenant=mocked.APIC_TENANT):
+        net_ctx = self._get_network_context(net_tenant,
+                                            mocked.APIC_NETWORK_PRE_EDGE_NAT,
+                                            TEST_SEGMENT1, external=True)
+        port_ctx = self._get_port_context(mocked.APIC_TENANT,
+                                          mocked.APIC_NETWORK_PRE_EDGE_NAT,
+                                          'vm1', net_ctx, HOST_ID1, gw=True)
+        mgr = self.driver.apic_manager
+        mgr.get_router_contract.return_value = mocked.FakeDbContract(
+            mocked.APIC_CONTRACT)
+        self.driver.l3out_vlan_alloc.reserve_vlan = mock.Mock()
+        self.driver._query_l3out_info = mock.Mock()
+        self.driver._query_l3out_info.return_value = {
+            'l3out_tenant': 'bar_tenant',
+            'vrf_name': 'bar_ctx',
+            'vrf_tenant': 'bar_tenant',
+
+            # fake l3out response from APIC for testing purpose only
+            'l3out': ([{u'l3extExtEncapAllocator': {}},
+                       {u'l3extInstP': {}},
+                       {u'l3extRtBDToOut': {}},
+                       {u'l3extRsOutToBDPublicSubnetHolder': {}},
+                       {u'l3extRsNdIfPol': {u'tDn': u'',
+                                            u'tnNdIfPolName': u''}},
+                       {u'l3extRsDampeningPol':
+                           {u'tDn': u'', u'tnRtctrlProfileName': u''}},
+                       {u'ospfRsIfPol': {u'tDn': u'',
+                                         u'tnOspfIfPolName': u''}},
+                       {u'l3extRsEngressQosDppPol':
+                           {u'tDn': u'', u'tnQosDppPolName': u''}},
+                       {u'bfdRsIfPol': {u'tDn': u'',
+                                        u'tnBfdIfPolName': u''}},
+                       {u'bgpRsPeerPfxPol': {u'tDn': u'',
+                                             u'tnBgpPeerPfxPolName': u''}},
+                       {u'eigrpRsIfPol': {u'tDn': u'',
+                                          u'tnEigrpIfPolName': u''}},
+                       {u'l3extLNodeP': {u'attributes':
+                                         {u'dn': u'uni/tn-bar_tenant/out-netwo\
+rk_pre_edge_nat-name/lnodep-Leaf3-4_NP',
+                                          u'lcOwn': u'local',
+                                          u'name': u'Leaf3-4_NP',
+                                          u'targetDscp': u'unspecified',
+                                          u'configIssues': u'',
+                                          u'stateQual': u'', u'tCl': u'',
+                                          u'tContextDn': u'', u'tRn': u'',
+                                          u'type': u'', u'rType': u'',
+                                          u'state': u'', u'forceResolve': u'',
+                                          u'tag': u'yellow-green',
+                                          u'monPolDn': u'', u'modTs': u'',
+                                          u'uid': u'15374',
+                                          u'encap': u'unknown',
+                                          u'addr': u'0.0.0.0'},
+                                         u'children': [{u'l3extLIfP':
+                                                        {u'children':
+                                                         [{u'l3extRsPathL3OutA\
+tt':
+                                                           {u'attributes':
+                                                            {u'encap':
+                                                             u'vlan-3101',
+                                                             u'ifInstT':
+                                                             u'sub-interface'
+                                                             }}}]}}
+                                                       ]}},
+                       {u'l3extRsEctx':
+                        {u'attributes':
+                         {u'dn':
+                          u'uni/tn-bar_tenant/out-network_pre_edge_nat-name\
+/rsectx',
+                          u'tDn': u'', u'tnFvCtxName': u'default'}}}])}
+
+        def echo1(string):
+            return string
+        self.driver.apic_manager.apic.fvTenant.rn = echo1
+        self.driver.apic_manager.apic.l3extOut.rn = echo1
+        self.driver.l3out_vlan_alloc.reserve_vlan.return_value = 999
+
+        self.driver.update_port_postcommit(port_ctx)
+        mgr.get_router_contract.assert_called_once_with(
+            self._scoped_name(port_ctx.current['device_id']),
+            owner=self._router_tenant())
+
+        self.driver.l3out_vlan_alloc.reserve_vlan.assert_called_once_with(
+            mocked.APIC_NETWORK_PRE_EDGE_NAT + '-name',
+            self._network_vrf_name(), self._tenant(ext_nat=True))
+        self.assertFalse(mgr.mgr.ensure_external_routed_network_created.called)
+        self.assertFalse(mgr.set_domain_for_external_routed_network.called)
+        self.assertFalse(mgr.ensure_logical_node_profile_created.called)
+        self.assertFalse(mgr.ensure_static_route_created.called)
+
+        l3out_name = (self.driver.per_tenant_context and
+                      self._scoped_name(mocked.APIC_NETWORK_PRE_EDGE_NAT) or
+                      mocked.APIC_NETWORK_PRE_EDGE_NAT)
+        l3out_name = "Auto-%s" % l3out_name
+
+        final_req = re.sub('Auto-Sub',
+                           l3out_name, self.trimmed_l3out)
+        final_req = re.sub('tn-Sub',
+                           "tn-%s" % self._tenant(ext_nat=True), final_req)
+        final_req = re.sub('ctx-Sub',
+                           "%s" % self._network_vrf_name(), final_req)
+        mgr.apic.post_body.assert_called_once_with(
+            mgr.apic.l3extOut.mo, final_req, self._tenant(ext_nat=True),
+            l3out_name)
+
+        mgr.ensure_external_epg_created.assert_called_once_with(
+            l3out_name,
+            external_epg="Shd-%s" % self._scoped_name(mocked.APIC_EXT_EPG,
+                                                      preexisting=True),
+            owner=self._tenant(ext_nat=True), transaction=mock.ANY)
+
+        expected_calls = [
+            mock.call(
+                l3out_name,
+                mgr.get_router_contract.return_value,
+                external_epg="Shd-%s" % self._scoped_name(mocked.APIC_EXT_EPG,
+                                                          preexisting=True),
+                owner=self._tenant(ext_nat=True), transaction=mock.ANY)]
+        self._check_call_list(
+            expected_calls,
+            mgr.ensure_external_epg_consumed_contract.call_args_list)
+
+        expected_calls = [
+            mock.call(
+                l3out_name,
+                mgr.get_router_contract.return_value,
+                external_epg="Shd-%s" % self._scoped_name(mocked.APIC_EXT_EPG,
+                                                          preexisting=True),
+                owner=self._tenant(ext_nat=True), transaction=mock.ANY)]
+        self._check_call_list(
+            expected_calls,
+            mgr.ensure_external_epg_provided_contract.call_args_list)
+
+    def test_update_pre_edge_nat_gw_port_postcommit(self):
+        self._test_update_pre_edge_nat_gw_port_postcommit()
+
+    def test_update_cross_tenant_pre_edge_nat_gw_port_postcommit(self):
+        self._test_update_pre_edge_nat_gw_port_postcommit('admin_tenant')
 
     def _test_update_pre_gw_port_postcommit(self,
                                             net_tenant=mocked.APIC_TENANT):
@@ -1496,23 +1655,45 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         mgr = self.driver.apic_manager
         mgr.delete_external_routed_network.assert_not_called()
 
-    def test_delete_asr_gw_port_postcommit(self):
+    def test_delete_edge_nat_gw_port_postcommit(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,
-                                            mocked.APIC_NETWORK_ASR,
+                                            mocked.APIC_NETWORK_EDGE_NAT,
                                             TEST_SEGMENT1, external=True)
         port_ctx = self._get_port_context(mocked.APIC_TENANT,
-                                          mocked.APIC_NETWORK_ASR,
+                                          mocked.APIC_NETWORK_EDGE_NAT,
                                           'vm1', net_ctx, HOST_ID1, gw=True)
         self.driver._delete_path_if_last = mock.Mock()
         self.driver.l3out_vlan_alloc.release_vlan = mock.Mock()
         self.driver.delete_port_postcommit(port_ctx)
         mgr = self.driver.apic_manager
         mgr.delete_external_routed_network.assert_called_once_with(
-            "Shd-%s" % (self.driver.per_tenant_context and
-                        self._scoped_name(mocked.APIC_NETWORK_ASR) or
-                        mocked.APIC_NETWORK_ASR),
+            "Auto-%s" % (self.driver.per_tenant_context and
+                         self._scoped_name(mocked.APIC_NETWORK_EDGE_NAT) or
+                         mocked.APIC_NETWORK_EDGE_NAT),
             owner=self._tenant(ext_nat=True))
-        self.assertTrue(self.driver.l3out_vlan_alloc.release_vlan.called)
+        self.driver.l3out_vlan_alloc.release_vlan.assert_called_once_with(
+            mocked.APIC_NETWORK_EDGE_NAT + '-name', self._network_vrf_name(),
+            self._tenant(ext_nat=True))
+
+    def test_delete_pre_edge_nat_gw_port_postcommit(self):
+        net_ctx = self._get_network_context(mocked.APIC_TENANT,
+                                            mocked.APIC_NETWORK_PRE_EDGE_NAT,
+                                            TEST_SEGMENT1, external=True)
+        port_ctx = self._get_port_context(mocked.APIC_TENANT,
+                                          mocked.APIC_NETWORK_PRE_EDGE_NAT,
+                                          'vm1', net_ctx, HOST_ID1, gw=True)
+        self.driver._delete_path_if_last = mock.Mock()
+        self.driver.l3out_vlan_alloc.release_vlan = mock.Mock()
+        self.driver.delete_port_postcommit(port_ctx)
+        mgr = self.driver.apic_manager
+        mgr.delete_external_routed_network.assert_called_once_with(
+            "Auto-%s" % (self.driver.per_tenant_context and
+                         self._scoped_name(mocked.APIC_NETWORK_PRE_EDGE_NAT) or
+                         mocked.APIC_NETWORK_PRE_EDGE_NAT),
+            owner=self._tenant(ext_nat=True))
+        self.driver.l3out_vlan_alloc.release_vlan.assert_called_once_with(
+            mocked.APIC_NETWORK_PRE_EDGE_NAT + '-name',
+            self._network_vrf_name(), self._tenant(ext_nat=True))
 
     def test_update_no_nat_gw_port_postcommit(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,


### PR DESCRIPTION
1. query preexisting L3out in APIC then clone it to the right tenant
2. trim those admin-only attributes; replace VRF, L3out name and
   encap before sending it to APIC as a request.
3. replace router_type=asr with edge_nat=true as we will need this mode
   for other types of routers too.
4. when edge_nat=true, replace Shd-<L3 out name> with Auto-<L3 out name>
   as this l3 out will also have node/IF profiles created.

TODO: still need to add some error-checking. Will do that thru a
different checkin then.
