### PR TITLE
Exclude empty-string tenant routers

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -908,7 +908,8 @@ class APICMechanismDriver(api.MechanismDriver,
                 context._plugin_context,
                 filters={'id': [p['device_id'] for p in router_gw_ports]})
             routers = [r for r in routers
-                       if r['tenant_id'] != router['tenant_id']]
+                       if r['tenant_id'] and
+                       r['tenant_id'] != router['tenant_id']]
             if routers:
                 raise OnlyOneRouterPermittedIfNatDisabled(net=network['name'])
 

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -1133,14 +1133,15 @@ l3extRsPathL3OutAtt": {"attributes": {"ifInstT": "sub-interface", "encap": \
         self.driver.create_port_postcommit(port_ctx)
         mgr.ensure_path_created_for_port.assert_not_called()
 
-    def test_create_port_precommit_empty_tenant(self):
-        self.driver._is_nat_enabled_on_ext_net = mock.Mock(return_value=True)
+    def test_update_port_precommit_empty_tenant_1(self):
+        self.driver._is_nat_enabled_on_ext_net = mock.Mock()
         self.driver._l3_plugin.get_router = mock.Mock(
             return_value={'id': mocked.APIC_ROUTER, 'tenant_id': ''})
         net_ctx = self._get_network_context(mocked.APIC_TENANT,
                                             mocked.APIC_NETWORK,
                                             TEST_SEGMENT1,
-                                            seg_type=ofcst.TYPE_OPFLEX)
+                                            seg_type=ofcst.TYPE_OPFLEX,
+                                            external=True)
         r_cnst = n_constants.DEVICE_OWNER_ROUTER_GW
         port_ctx = self._get_port_context(mocked.APIC_TENANT,
                                           mocked.APIC_NETWORK,
@@ -1149,8 +1150,35 @@ l3extRsPathL3OutAtt": {"attributes": {"ifInstT": "sub-interface", "encap": \
                                           device_owner=r_cnst)
         self.assertTrue(self.driver._check_segment_for_agent(
             port_ctx._bound_segment, self.agent))
-        self.driver.create_port_precommit(port_ctx)
+        self.driver.update_port_precommit(port_ctx)
         self.driver._is_nat_enabled_on_ext_net.assert_not_called()
+
+    def test_update_port_precommit_empty_tenant_2(self):
+        self.driver._is_nat_enabled_on_ext_net = mock.Mock(return_value=False)
+        self.driver.per_tenant_context = True
+        self.driver._is_edge_nat = mock.Mock(return_value=False)
+        self.driver._is_pre_existing = mock.Mock(return_value=False)
+        self.driver._l3_plugin.get_router = mock.Mock(
+            return_value={'id': mocked.APIC_ROUTER, 'tenant_id': 'foo'})
+        self.driver._l3_plugin.get_routers = mock.Mock(
+            return_value=[{'id': mocked.APIC_ROUTER, 'tenant_id': ''}])
+        net_ctx = self._get_network_context(mocked.APIC_TENANT,
+                                            mocked.APIC_NETWORK,
+                                            TEST_SEGMENT1,
+                                            seg_type=ofcst.TYPE_OPFLEX,
+                                            external=True)
+        r_cnst = n_constants.DEVICE_OWNER_ROUTER_GW
+        port_ctx = self._get_port_context(mocked.APIC_TENANT,
+                                          mocked.APIC_NETWORK,
+                                          mocked.APIC_ROUTER,
+                                          net_ctx, HOST_ID1,
+                                          device_owner=r_cnst)
+        self.assertTrue(self.driver._check_segment_for_agent(
+            port_ctx._bound_segment, self.agent))
+        self.driver.update_port_precommit(port_ctx)
+        self.driver._l3_plugin.get_routers.assert_called_once_with(
+            mock.ANY, filters=mock.ANY)
+        self.driver._is_pre_existing.assert_called_once_with(mock.ANY)
 
     def test_create_port_postcommit_empty_tenant(self):
         self.driver._create_shadow_ext_net_for_nat = mock.Mock()


### PR DESCRIPTION
Don't include empty-string tenants when inspecting
routers -- the Cisco Router Service Plugin (ASR code)
creates "hidden" routers by assigning them empty-string
tenant IDs. These routers aren't meant to handle configuration
of the APIC, and therefore must be excluded from any lists
of routers used by this driver.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
