### PR TITLE
Fix multiple router delete failure

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -1584,10 +1584,7 @@ class APICMechanismDriver(api.MechanismDriver,
 
         if remove_contracts_only:
             external_epg = apic_manager.EXT_EPG
-            arouter_id = self.name_mapper.router(
-                context, router['id'], openstack_owner=router['tenant_id'])
-            contract = self.apic_manager.get_router_contract(
-                arouter_id, owner=self._get_router_aci_tenant(router))
+            contract = 'contract-%s' % router['id']
             if self._is_pre_existing(ext_info) and 'external_epg' in ext_info:
                 external_epg = self.name_mapper.pre_existing(
                     context, ext_info['external_epg'])

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -2487,8 +2487,6 @@ tt':
 
         self.driver._delete_path_if_last = mock.Mock()
         mgr = self.driver.apic_manager
-        mgr.get_router_contract.return_value = mocked.FakeDbContract(
-            mocked.APIC_CONTRACT + 'r1')
 
         # Delete first GW port
         self.driver.delete_port_postcommit(gw_ports[0])
@@ -2498,12 +2496,12 @@ tt':
                 "Shd-%s" % self._scoped_name(ext_net_name, tenant='t1'))
         exp_calls = [
             mock.call(shadow_l3out,
-                      mgr.get_router_contract.return_value,
+                      'contract-r1',
                       external_epg=shadow_ext_epg,
                       owner=self._tenant(ext_nat=True, neutron_tenant='t1'),
                       provided=True),
             mock.call(shadow_l3out,
-                      mgr.get_router_contract.return_value,
+                      'contract-r1',
                       external_epg=shadow_ext_epg,
                       owner=self._tenant(ext_nat=True, neutron_tenant='t1'),
                       provided=False)
@@ -2514,8 +2512,6 @@ tt':
 
         # Delete second GW port
         mgr.unset_contract_for_external_epg.reset_mock()
-        mgr.get_router_contract.return_value = mocked.FakeDbContract(
-            mocked.APIC_CONTRACT + 'r2')
         self.driver.delete_port_postcommit(gw_ports[0])
 
         if self.driver.per_tenant_context:
@@ -2530,11 +2526,11 @@ tt':
 
             exp_calls = [
                 mock.call(shadow_l3out,
-                          mgr.get_router_contract.return_value,
+                          'contract-r2',
                           external_epg=shadow_ext_epg,
                           owner=self._tenant(ext_nat=True), provided=True),
                 mock.call(shadow_l3out,
-                          mgr.get_router_contract.return_value,
+                          'contract-r2',
                           external_epg=shadow_ext_epg,
                           owner=self._tenant(ext_nat=True), provided=False)
             ]


### PR DESCRIPTION
Calling 'get_router_contract' during gateway-port delete
can inadvertently create an entry for the router in
table cisco_ml2_apic_contracts. This leads to a stray
entry when a router is being deleted with gateway-set.

Fixes #102

Signed-off-by: Amit Bose amitbose@gmail.com
