### PR TITLE
use the scoped name for the VRF also while cloning l3out

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -1558,7 +1558,7 @@ class APICMechanismDriver(api.MechanismDriver,
                 # out this shadow L3 out in APIC
                 if is_edge_nat:
                     vlan_id = self.l3out_vlan_alloc.reserve_vlan(
-                        network['name'], str(vrf_info['aci_name']),
+                        network['name'], vrf_info['aci_name'],
                         vrf_info['aci_tenant'])
                     encap = 'vlan-' + str(vlan_id)
                     if not self._is_pre_existing(net_info):
@@ -1580,9 +1580,11 @@ class APICMechanismDriver(api.MechanismDriver,
                             owner=vrf_info['aci_tenant'],
                             transaction=trs)
                     else:
-                        self._clone_l3out(context, str(nat_epg_tenant),
-                                          str(vrf_info['aci_tenant']),
-                                          str(vrf_info['aci_name']), network,
+                        vrf = self.apic_manager.apic.fvCtx.name(
+                            vrf_info['aci_name'])
+                        self._clone_l3out(context, nat_epg_tenant,
+                                          vrf_info['aci_tenant'],
+                                          vrf, network,
                                           shadow_l3out, encap)
 
                     # queries all the BDs connected to this router

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -1506,10 +1506,11 @@ tt':
 /rsectx',
                           u'tDn': u'', u'tnFvCtxName': u'default'}}}])}
 
-        def echo1(string):
-            return string
+        def echo1(obj):
+            return str(obj)
         self.driver.apic_manager.apic.fvTenant.rn = echo1
         self.driver.apic_manager.apic.l3extOut.rn = echo1
+        self.driver.apic_manager.apic.fvCtx.name = echo1
         self.driver.l3out_vlan_alloc.reserve_vlan.return_value = 999
 
         manager.NeutronManager = mock.MagicMock()


### PR DESCRIPTION
1. also use a better echo1() API to deal with UTs.
