### PR TITLE
Also allow SVI while cloning the Auto-l3out

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -130,9 +130,8 @@ class EdgeNatBadVlanRange(n_exc.BadRequest):
 
 
 class EdgeNatWrongL3OutIFType(n_exc.BadRequest):
-    message = _("L3Out %(l3out)s can only support routed "
-                "sub-interfaces in the interface profiles when edge_nat"
-                "is enabled.")
+    message = _("L3Out %(l3out)s can only support routed sub-interfaces and "
+                "SVI in the interface profiles when edge_nat is enabled.")
 
 
 class EdgeNatWrongL3OutAuthTypeForBGP(n_exc.BadRequest):
@@ -1006,7 +1005,8 @@ class APICMechanismDriver(api.MechanismDriver,
                 l3out_str = str(l3out_info['l3out'])
                 for match in re.finditer("u'ifInstT': u'([^']+)'",
                                          l3out_str):
-                    if match.group(1) != 'sub-interface':
+                    if (match.group(1) != 'sub-interface' and
+                            match.group(1) != 'ext-svi'):
                         raise EdgeNatWrongL3OutIFType(l3out=network['name'])
                 for match in re.finditer("u'authType': u'([^']+)'",
                                          l3out_str):

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -2494,7 +2494,7 @@ tt':
                         u'children': [{u'l3extLIfP':
                                        {u'children': [{u'l3extRsPathL3OutAtt':
                                                        {u'attributes':
-                                                        {u'ifInstT': u'ext-svi'
+                                                        {u'ifInstT': u'l3-port'
                                                          }}}]}}]}}]}
         self.assertRaises(md.EdgeNatWrongL3OutIFType,
                           self.driver.update_port_precommit,


### PR DESCRIPTION
1. SVI is meant for L2 however if user knows what they are doing
   and already pre-configured it properly then we should allow it.
