### PR TITLE
Use shallow copy of context object for DVS RPC

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -337,12 +337,13 @@ class APICMechanismDriver(api.MechanismDriver,
                                                   (aci_tenant,
                                                    app_profile,
                                                    epg))
-            context.current['portgroup_name'] = (
+            currentcopy = copy.copy(context.current)
+            currentcopy['portgroup_name'] = (
                 vif_details['dvs_port_group_name'])
             booked_port_key = None
             if self.dvs_notifier:
                 booked_port_key = self.dvs_notifier.bind_port_call(
-                    context.current,
+                    currentcopy,
                     context.network.network_segments,
                     context.network.current,
                     context.host


### PR DESCRIPTION
The RPC call for bind_port modifies the context object
to pass the port group name. A shallow copy of the context
object should be used instead, so that the original context
object isn't modified.

This closes #189

Signed-off-by: Thomas Bachman tbachman@yahoo.com
