### PR TITLE
Allow connecting non-virtual nodes to OpFlex networks

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -314,7 +314,11 @@ class APICMechanismDriver(api.MechanismDriver,
         # environment supporting KVM and ESX compute). Go try for
         # OpFlex agents.
         agent_list = context.host_agents(ofcst.AGENT_TYPE_OPFLEX_OVS)
-        self._agent_bind_port(context, agent_list, self._bind_opflex_port)
+        if self._agent_bind_port(context, agent_list, self._bind_opflex_port):
+            return
+
+        # Try hierarchical binding for physical nodes
+        self._bind_physical_node(context)
 
     def _bind_dvs_port(self, context, segment, agent):
         """Populate VIF type and details for DVS VIFs.
@@ -364,12 +368,7 @@ class APICMechanismDriver(api.MechanismDriver,
            set when this mechanism driver was instantiated.
         """
         if self._check_segment_for_agent(segment, agent):
-            context.set_binding(segment[api.ID],
-                                portbindings.VIF_TYPE_OVS,
-                                {portbindings.CAP_PORT_FILTER:
-                                 self.sg_enabled,
-                                 portbindings.OVS_HYBRID_PLUG:
-                                 self.sg_enabled})
+            self._complete_binding(context, segment)
             return True
         else:
             return False
@@ -394,6 +393,40 @@ class APICMechanismDriver(api.MechanismDriver,
             return True
         else:
             return False
+
+    def _get_physical_network_for_host(self, host):
+        for k, v in self.apic_manager.phy_net_dict.iteritems():
+            if host in v.get('hosts', []):
+                return k
+
+    def _bind_physical_node(self, context):
+        phy_seg_name = self._get_physical_network_for_host(context.host)
+        if phy_seg_name:
+            phy_seg = self.apic_manager.phy_net_dict[phy_seg_name]
+            for segment in context.segments_to_bind:
+                net_type = segment[api.NETWORK_TYPE]
+                if net_type == ofcst.TYPE_OPFLEX:
+                    dyn_seg = context.allocate_dynamic_segment(
+                        {api.PHYSICAL_NETWORK: phy_seg_name,
+                         api.NETWORK_TYPE:
+                            phy_seg.get('segment_type', constants.TYPE_VLAN)})
+                    LOG.info("Allocated dynamic-segment %(s)s for port %(p)s",
+                             {'s': dyn_seg, 'p': context.current['id']})
+                    dyn_seg['apic_ml2_created'] = True
+                    context.continue_binding(segment['id'], [dyn_seg])
+                    return True
+                elif segment.get('apic_ml2_created'):
+                    # complete binding if another driver did not bind the
+                    # dynamic segment that we created
+                    self._complete_binding(context, segment)
+                    return True
+        return False
+
+    def _complete_binding(self, context, segment):
+        context.set_binding(segment[api.ID],
+                            portbindings.VIF_TYPE_OVS,
+                            {portbindings.CAP_PORT_FILTER: self.sg_enabled,
+                             portbindings.OVS_HYBRID_PLUG: self.sg_enabled})
 
     def initialize(self):
         # initialize apic
@@ -513,7 +546,7 @@ class APICMechanismDriver(api.MechanismDriver,
         def is_port_promiscuous(port):
             return port['device_owner'] == n_constants.DEVICE_OWNER_DHCP
 
-        segment = port_context.top_bound_segment or {}
+        segment = port_context.bottom_bound_segment or {}
         details = {'device': kwargs.get('device'),
                    'port_id': port_id,
                    'mac_address': port['mac_address'],
@@ -809,13 +842,13 @@ class APICMechanismDriver(api.MechanismDriver,
                 context, network['id'], openstack_owner=network['tenant_id'])
             epg_name = self._get_ext_epg_for_ext_net(l3out_name)
         # Get segmentation id
-        if not context.top_bound_segment:
+        if not context.bottom_bound_segment:
             LOG.debug("Port %s is not bound to a segment", port)
             return
         seg = None
-        if (context.top_bound_segment.get(api.NETWORK_TYPE)
+        if (context.bottom_bound_segment.get(api.NETWORK_TYPE)
                 in [constants.TYPE_VLAN]):
-            seg = context.top_bound_segment.get(api.SEGMENTATION_ID)
+            seg = context.bottom_bound_segment.get(api.SEGMENTATION_ID)
         # hosts on which this vlan is provisioned
         host = context.host
         # Create a static path attachment for the host/epg/switchport combo
@@ -1028,8 +1061,8 @@ class APICMechanismDriver(api.MechanismDriver,
             self._perform_gw_port_operations(context, port)
         elif port.get('device_owner') == n_constants.DEVICE_OWNER_ROUTER_INTF:
             self._perform_interface_port_operations(context, port)
-        elif self._is_port_bound(port) and not self._is_apic_network_type(
-                context):
+        elif (self._is_port_bound(port) and
+              self._port_needs_static_path_binding(context)):
             self._perform_path_port_operations(context, port)
         self._notify_ports_due_to_router_update(port)
 
@@ -1091,28 +1124,30 @@ class APICMechanismDriver(api.MechanismDriver,
                     network_tenant, l3out_name_pre or l3out_name, None,
                     transaction=trs)
 
-    def _get_active_path_count(self, context, host=None):
+    def _get_active_path_count(self, context, host, segment):
         return context._plugin_context.session.query(
             models.PortBindingLevel).filter_by(
-                host=host or context.host,
-                segment_id=context.top_bound_segment['id']).count()
+                host=host, segment_id=segment['id']).count()
 
     @lockutils.synchronized('apic-portlock')
     def _delete_port_path(self, context, atenant_id, anetwork_id,
-                          app_profile_name, host=None):
-        if not self._get_active_path_count(context):
+                          app_profile_name, host, segment):
+        if not self._get_active_path_count(context, host, segment):
             self.apic_manager.ensure_path_deleted_for_port(
-                atenant_id, anetwork_id,
-                host or context.host, app_profile_name=app_profile_name)
+                atenant_id, anetwork_id, host,
+                app_profile_name=app_profile_name)
 
-    def _delete_path_if_last(self, context, host=None):
-        if not self._get_active_path_count(context):
+    def _delete_path_if_last(self, context, host=None, segment=None):
+        host = host or context.host
+        segment = segment or context.bottom_bound_segment
+        if not self._get_active_path_count(context, host, segment):
             atenant_id = self._get_network_aci_tenant(context.network.current)
             network_id = context.network.current['id']
             epg_name = self.name_mapper.endpoint_group(context, network_id)
-            self._delete_port_path(context, atenant_id, epg_name,
-                                   self._get_network_app_profile(
-                                       context.network.current), host=host)
+            self._delete_port_path(
+                context, atenant_id, epg_name,
+                self._get_network_app_profile(context.network.current),
+                host, segment)
 
     def _get_subnet_info(self, context, subnet):
         if subnet['gateway_ip']:
@@ -1168,11 +1203,14 @@ class APICMechanismDriver(api.MechanismDriver,
         self._check_gw_port_operation(context, context.current)
 
     def update_port_postcommit(self, context):
-        if (not self._is_apic_network_type(context) and
-                context.original_host and (context.original_host !=
+        if (self._port_needs_static_path_binding(context, use_original=True)
+            and context.original_host and (context.original_host !=
                                            context.host)):
             # The VM was migrated
-            self._delete_path_if_last(context, host=context.original_host)
+            self._delete_path_if_last(
+                context, host=context.original_host,
+                segment=context.original_bottom_bound_segment)
+            self._release_dynamic_segment(context, use_original=True)
         self._perform_port_operations(context)
         port = context.current
         if (port.get('binding:vif_details') and
@@ -1198,10 +1236,10 @@ class APICMechanismDriver(api.MechanismDriver,
     def delete_port_postcommit(self, context):
         port = context.current
         network = context.network.current
-        # Check if a compute port
-        if (not self._is_apic_network_type(context) and
-                self._is_port_bound(port) and context.top_bound_segment):
+        if (self._port_needs_static_path_binding(context) and
+                self._is_port_bound(port) and context.bottom_bound_segment):
             self._delete_path_if_last(context)
+            self._release_dynamic_segment(context)
         if port.get('device_owner') == n_constants.DEVICE_OWNER_ROUTER_GW:
             if self._is_nat_enabled_on_ext_net(network):
                 self._delete_shadow_ext_net_for_nat(context, port, network)
@@ -1353,11 +1391,14 @@ class APICMechanismDriver(api.MechanismDriver,
             portbindings.VIF_TYPE_UNBOUND,
             portbindings.VIF_TYPE_BINDING_FAILED]
 
-    def _is_apic_network_type(self, port_context):
-        return self._is_apic_network(port_context.network.current)
+    def _is_opflex_type(self, net_type):
+        return net_type == ofcst.TYPE_OPFLEX
+
+    def _is_supported_non_opflex_type(self, net_type):
+        return net_type in [constants.TYPE_VLAN]
 
     def _is_apic_network(self, network):
-        return network['provider:network_type'] == ofcst.TYPE_OPFLEX
+        return self._is_opflex_type(network['provider:network_type'])
 
     def notify_port_update(self, port_id, context=None):
         context = context or nctx.get_admin_context()
@@ -2158,3 +2199,30 @@ class APICMechanismDriver(api.MechanismDriver,
         router_gw_ports = context._plugin.get_ports(
             context._plugin_context.elevated(), filters=gw_port_filter)
         return (not [p for p in router_gw_ports if p['id'] != gw_port['id']])
+
+    def _port_needs_static_path_binding(self, port_context,
+                                        use_original=False):
+        bound_seg = (port_context.original_bottom_bound_segment if use_original
+                     else port_context.bottom_bound_segment)
+        return (not self._is_apic_network(port_context.network.current) or
+                (bound_seg and self._is_supported_non_opflex_type(
+                    bound_seg[api.NETWORK_TYPE])))
+
+    def _release_dynamic_segment(self, port_context, use_original=False):
+        top = (port_context.original_top_bound_segment if use_original
+               else port_context.top_bound_segment)
+        btm = (port_context.original_bottom_bound_segment if use_original
+               else port_context.bottom_bound_segment)
+        if (top and btm and
+                self._is_opflex_type(top[api.NETWORK_TYPE]) and
+                self._is_supported_non_opflex_type(btm[api.NETWORK_TYPE])):
+            # if there are no other ports bound to segment, release it
+            num_binds = port_context._plugin_context.session.query(
+                models.PortBindingLevel).filter_by(
+                    segment_id=btm[api.ID]).filter(
+                        models.PortBindingLevel.port_id !=
+                        port_context.current['id']).count()
+            if not num_binds:
+                LOG.info("Releasing dynamic-segment %(s)s for port %(p)s",
+                         {'s': btm, 'p': port_context.current['id']})
+                port_context.release_dynamic_segment(btm[api.ID])

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -92,6 +92,12 @@ AGENT_TYPE_DVS = acst.AGENT_TYPE_DVS
 AGENT_CONF_DVS = {'alive': True, 'binary': 'anotherbinary',
                   'topic': 'anothertopic', 'agent_type': AGENT_TYPE_DVS,
                   'configurations': {'opflex_networks': None}}
+AGENT_CONF_OPFLEX = {'alive': True, 'binary': 'somebinary',
+                     'topic': 'sometopic',
+                     'agent_type': ofcst.AGENT_TYPE_OPFLEX_OVS,
+                     'configurations': {
+                         'opflex_networks': None,
+                         'bridge_mappings': {'physnet1': 'br-eth1'}}}
 
 
 def echo(context, id, prefix=''):
@@ -144,6 +150,7 @@ class ApicML2IntegratedTestBase(test_plugin.NeutronDbPluginV2TestCase,
         md.APICMechanismDriver.get_base_synchronizer = mock.Mock(
             return_value=self.synchronizer)
         self.driver.name_mapper.aci_mapper.tenant = echo
+        self.driver.apic_manager.apic = mock.Mock()
         self.driver.apic_manager.apic.transaction = self.fake_transaction
         self.rpc = self.driver.topology_endpoints[0]
         self.db = self.driver.apic_manager.db
@@ -1033,7 +1040,6 @@ class TestCiscoApicMechDriver(base.BaseTestCase,
         self.synchronizer = mock.Mock()
         md.APICMechanismDriver.get_base_synchronizer = mock.Mock(
             return_value=self.synchronizer)
-        md.APICMechanismDriver.get_apic_manager = mock.Mock()
         apic_mapper.ApicName.__eq__ = equal
         self.driver.apic_manager = mock.Mock(
             name_mapper=mock.Mock(), ext_net_dict=self.external_network_dict)
@@ -2880,7 +2886,7 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             self.assertIsNotNone(port_key)
             self.assertEqual(port_key, BOOKED_PORT_VALUE)
             self._verify_dvs_notifier('update_postcommit_port_call', p1, 'h1')
-            net_ctx = FakeNetworkContext(net, [mock.Mock()])
+            net_ctx = FakeNetworkContext(net, [{'network_type': 'opflex'}])
             port_ctx = FakePortContext(newp1['port'], net_ctx)
             self.driver.delete_port_postcommit(port_ctx)
             self._verify_dvs_notifier('delete_port_call', p1, 'h1')
@@ -2911,7 +2917,7 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             self.assertIsNotNone(port_key)
             self.assertEqual(port_key, BOOKED_PORT_VALUE)
             self._verify_dvs_notifier('update_postcommit_port_call', p1, 'h2')
-            net_ctx = FakeNetworkContext(net, [mock.Mock()])
+            net_ctx = FakeNetworkContext(net, [{'network_type': 'opflex'}])
             port_ctx = FakePortContext(newp1['port'], net_ctx)
             self.driver.delete_port_postcommit(port_ctx)
             self._verify_dvs_notifier('delete_port_call', p1, 'h2')
@@ -2939,7 +2945,7 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             self.assertIsNone(port_key)
             dvs_mock = self.driver.dvs_notifier.update_postcommit_port_call
             dvs_mock.assert_not_called()
-            net_ctx = FakeNetworkContext(net, [mock.Mock()])
+            net_ctx = FakeNetworkContext(net, [{'network_type': 'opflex'}])
             port_ctx = FakePortContext(newp1['port'], net_ctx)
             self.driver.delete_port_postcommit(port_ctx)
             dvs_mock = self.driver.dvs_notifier.delete_port_call
@@ -2957,7 +2963,7 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             port_key = newp2['port']['binding:vif_details'].get('dvs_port_key')
             self.assertIsNone(port_key)
             dvs_mock.assert_not_called()
-            net_ctx = FakeNetworkContext(net, [mock.Mock()])
+            net_ctx = FakeNetworkContext(net, [{'network_type': 'opflex'}])
             port_ctx = FakePortContext(newp2['port'], net_ctx)
             self.driver.delete_port_postcommit(port_ctx)
             dvs_mock = self.driver.dvs_notifier.delete_port_call
@@ -2988,7 +2994,7 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             self.assertIsNotNone(port_key)
             self.assertEqual(port_key, BOOKED_PORT_VALUE)
             self._verify_dvs_notifier('update_postcommit_port_call', p1, 'h1')
-            net_ctx = FakeNetworkContext(net, [mock.Mock()])
+            net_ctx = FakeNetworkContext(net, [{'network_type': 'opflex'}])
             port_ctx = FakePortContext(newp1['port'], net_ctx)
             self.driver.delete_port_postcommit(port_ctx)
             self._verify_dvs_notifier('delete_port_call', p1, 'h1')
@@ -3006,7 +3012,7 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             self.assertIsNone(port_key)
             dvs_mock = self.driver.dvs_notifier.update_postcommit_port_call
             dvs_mock.assert_not_called()
-            net_ctx = FakeNetworkContext(net, [mock.Mock()])
+            net_ctx = FakeNetworkContext(net, [{'network_type': 'opflex'}])
             port_ctx = FakePortContext(newp2['port'], net_ctx)
             self.driver.delete_port_postcommit(port_ctx)
             dvs_mock = self.driver.dvs_notifier.delete_port_call
@@ -3035,7 +3041,7 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
             self.assertIsNotNone(port_key)
             self.assertEqual(port_key, BOOKED_PORT_VALUE)
             self._verify_dvs_notifier('update_postcommit_port_call', p1, 'h1')
-            net_ctx = FakeNetworkContext(net, [mock.Mock()])
+            net_ctx = FakeNetworkContext(net, [{'network_type': 'opflex'}])
             port_ctx = FakePortContext(newp1['port'], net_ctx)
             self.driver.delete_port_postcommit(port_ctx)
             self._verify_dvs_notifier('delete_port_call', p1, 'h1')
@@ -3106,6 +3112,160 @@ class ApicML2IntegratedTestCaseSingleTenantSingleContext(
                            'ml2_cisco_apic')
         super(ApicML2IntegratedTestCaseSingleTenantSingleContext,
               self).setUp(service_plugins)
+
+
+class TestApicML2IntegratedPhysicalNode(ApicML2IntegratedTestBase):
+
+    def setUp(self, mech_drivers=None, service_plugins=None):
+        ml2_opts = {
+            'mechanism_drivers': mech_drivers or ['cisco_apic_ml2'],
+            'tenant_network_types': ['opflex'],
+            'type_drivers': ['opflex', 'vlan'],
+        }
+        super(TestApicML2IntegratedPhysicalNode, self).setUp(
+            service_plugins=service_plugins, ml2_opts=ml2_opts)
+        self.driver.agent_type = ofcst.AGENT_TYPE_OPFLEX_OVS
+        self.driver.apic_manager.phy_net_dict = {
+            'physnet1': {'hosts': set(['fw-app-01', 'lb-app-01'])}}
+        self.mgr.ensure_path_created_for_port = mock.Mock()
+        self.mgr.ensure_path_deleted_for_port = mock.Mock()
+        self._register_agent('fw-app-01')
+        self._register_agent('lb-app-01')
+        self.expected_bound_driver = 'cisco_apic_ml2'
+
+    def _get_bound_seg(self, port_id):
+        port_context = self.plugin.get_bound_port_context(
+            context.get_admin_context(), port_id)
+        if port_context:
+            driver = (port_context.binding_levels[-1]['bound_driver']
+                      if port_context.binding_levels else None)
+            return port_context.bottom_bound_segment, driver
+
+    def _query_dynamic_seg(self, network_id):
+        return ml2_db.get_network_segments(
+            context.get_admin_context().session, network_id,
+            filter_dynamic=True)
+
+    def test_physical_bind(self):
+        tenant1 = self._tenant(neutron_tenant='onetenant')
+        app_prof1 = self._app_profile(neutron_tenant='onetenant')
+
+        self._register_agent('h1', agent_cfg=AGENT_CONF_OPFLEX)
+
+        net1 = self.create_network(tenant_id='onetenant',
+                                   expected_res_status=201)['network']
+        sub1 = self.create_subnet(
+            network_id=net1['id'], cidr='192.168.0.0/24',
+            is_admin_context=True, ip_version=4)
+        with self.port(subnet=sub1, tenant_id='onetenant') as p:
+            p1 = p['port']
+
+        # bind to VM-host
+        self._bind_port_to_host(p1['id'], 'h1')
+        bseg_p1, bdriver = self._get_bound_seg(p1['id'])
+        self.assertEqual(bseg_p1['network_type'], 'opflex')
+        self.assertEqual('cisco_apic_ml2', bdriver)
+        self.mgr.ensure_path_created_for_port.assert_not_called()
+
+        # bind to one physical node
+        self._bind_port_to_host(p1['id'], 'fw-app-01')
+        bseg_p1, bdriver = self._get_bound_seg(p1['id'])
+        self.assertEqual(bseg_p1['network_type'], 'vlan')
+        self.assertEqual(self.expected_bound_driver, bdriver)
+        self.assertEqual(1, len(self._query_dynamic_seg(net1['id'])))
+        self.mgr.ensure_path_created_for_port.assert_called_once_with(
+            tenant1, net1['id'], 'fw-app-01', bseg_p1['segmentation_id'],
+            app_profile_name=app_prof1, transaction=mock.ANY)
+        self.mgr.ensure_path_created_for_port.reset_mock()
+
+        # bind another physical node to same network, then delete that port
+        with self.port(subnet=sub1, tenant_id='onetenant') as p1_1:
+            p1_1 = p1_1['port']
+            self._bind_port_to_host(p1_1['id'], 'lb-app-01')
+            self.assertEqual(bseg_p1, self._get_bound_seg(p1_1['id'])[0])
+            self.assertEqual(1, len(self._query_dynamic_seg(net1['id'])))
+            self.mgr.ensure_path_created_for_port.assert_called_once_with(
+                tenant1, net1['id'], 'lb-app-01', bseg_p1['segmentation_id'],
+                app_profile_name=app_prof1, transaction=mock.ANY)
+
+            self.delete_port(p1_1['id'], tenant_id=p1_1['tenant_id'])
+            self.assertEqual(1, len(self._query_dynamic_seg(net1['id'])))
+            self.mgr.ensure_path_deleted_for_port.assert_called_once_with(
+                tenant1, net1['id'], 'lb-app-01', app_profile_name=app_prof1)
+        self.mgr.ensure_path_created_for_port.reset_mock()
+        self.mgr.ensure_path_deleted_for_port.reset_mock()
+
+        # bind p1 back to VM-host
+        self._bind_port_to_host(p1['id'], 'h1')
+        bseg_p1, bdriver = self._get_bound_seg(p1['id'])
+        self.assertEqual('cisco_apic_ml2', bdriver)
+        self.assertEqual(bseg_p1['network_type'], 'opflex')
+        self.assertEqual(0, len(self._query_dynamic_seg(net1['id'])))
+        self.mgr.ensure_path_deleted_for_port.assert_called_once_with(
+            tenant1, net1['id'], 'fw-app-01', app_profile_name=app_prof1)
+        self.mgr.ensure_path_deleted_for_port.reset_mock()
+
+    def test_physical_bind_multiple_network(self):
+        tenant1 = self._tenant(neutron_tenant='onetenant')
+        app_prof1 = self._app_profile(neutron_tenant='onetenant')
+
+        net1 = self.create_network(tenant_id='onetenant',
+                                   expected_res_status=201)['network']
+        sub1 = self.create_subnet(
+            network_id=net1['id'], cidr='192.168.0.0/24',
+            is_admin_context=True, ip_version=4)
+        net2 = self.create_network(tenant_id='onetenant',
+                                   expected_res_status=201)['network']
+        sub2 = self.create_subnet(
+            network_id=net2['id'], cidr='192.168.0.0/24',
+            is_admin_context=True, ip_version=4)
+        with self.port(subnet=sub1, tenant_id='onetenant') as p:
+            p1 = p['port']
+        with self.port(subnet=sub2, tenant_id='onetenant') as p:
+            p2 = p['port']
+
+        self._bind_port_to_host(p1['id'], 'fw-app-01')
+        bseg_p1, bdriver = self._get_bound_seg(p1['id'])
+        self.assertEqual(self.expected_bound_driver, bdriver)
+        self.mgr.ensure_path_created_for_port.assert_called_once_with(
+            tenant1, net1['id'], 'fw-app-01', bseg_p1['segmentation_id'],
+            app_profile_name=app_prof1, transaction=mock.ANY)
+        self.mgr.ensure_path_created_for_port.reset_mock()
+
+        # bind port from another network to first physical node
+        self._bind_port_to_host(p2['id'], 'fw-app-01')
+        bseg_p2, bdriver = self._get_bound_seg(p2['id'])
+        self.assertEqual(self.expected_bound_driver, bdriver)
+        self.assertEqual(bseg_p2['network_type'], 'vlan')
+        self.assertNotEqual(bseg_p1['segmentation_id'],
+                            bseg_p2['segmentation_id'])
+        self.assertEqual(1, len(self._query_dynamic_seg(net2['id'])))
+        self.mgr.ensure_path_created_for_port.assert_called_once_with(
+            tenant1, net2['id'], 'fw-app-01', bseg_p2['segmentation_id'],
+            app_profile_name=app_prof1, transaction=mock.ANY)
+
+        # delete the ports
+        self.delete_port(p1['id'], tenant_id=p1['tenant_id'])
+        self.assertEqual(0, len(self._query_dynamic_seg(net1['id'])))
+        self.mgr.ensure_path_deleted_for_port.assert_called_once_with(
+            tenant1, net1['id'], 'fw-app-01', app_profile_name=app_prof1)
+        self.mgr.ensure_path_deleted_for_port.reset_mock()
+
+        self.delete_port(p2['id'], tenant_id=p2['tenant_id'])
+        self.assertEqual(0, len(self._query_dynamic_seg(net2['id'])))
+        self.mgr.ensure_path_deleted_for_port.assert_called_once_with(
+            tenant1, net2['id'], 'fw-app-01', app_profile_name=app_prof1)
+        self.mgr.ensure_path_deleted_for_port.reset_mock()
+
+
+class TestApicML2IntegratedPhysicalNodeMultiDriver(
+    TestApicML2IntegratedPhysicalNode):
+
+    def setUp(self, service_plugins=None):
+        super(TestApicML2IntegratedPhysicalNodeMultiDriver, self).setUp(
+            mech_drivers=['openvswitch', 'cisco_apic_ml2'],
+            service_plugins=service_plugins)
+        self.expected_bound_driver = 'openvswitch'
 
 
 class TestCiscoApicMechDriverSingleVRF(TestCiscoApicMechDriver):
@@ -3399,8 +3559,11 @@ class FakePortContext(object):
         self.original = self._port
         self.network = self._network
         self.top_bound_segment = self._bound_segment
+        self.bottom_bound_segment = self._bound_segment
         self.host = self._port.get(portbindings.HOST_ID)
         self.original_host = None
+        self.original_top_bound_segment = None
+        self.original_bottom_bound_segment = None
         self._binding = mock.Mock()
         self._binding.segment = self._bound_segment
 


### PR DESCRIPTION
Currently, OpFlex virtual networks support only virtual
endpoints created on KVM hosts. With this change,
non-virtual nodes, like service appliances, can also be
configured to be part of the same network that VMs
are connected to. This is achieved by statically binding
specific switch ports in ACI fabric to the corresponding EPG
using VLAN-encapsulation. For this we use hierarchical
port-binding - when Neutron ports bind to particular hosts,
the mechanism driver creates a dynamic VLAN
segment and allows other drivers to complete the binding
(if no other mechanism drivers complete the binding, we
complete the binding for the dynamic segment).
Static path-binding is configured on APIC when port-binding
is successful in Neutron.

Closes noironetworks/support#113

Signed-off-by: Amit Bose amitbose@gmail.com
