### PR TITLE
Link BDs to L3Outs even when NAT is disabled

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -858,10 +858,10 @@ class APICMechanismDriver(api.MechanismDriver,
                 app_profile_name=self._get_network_app_profile(
                     context.network.current), transaction=trs)
 
-    def _perform_interface_port_operations(self, context, port,
+    def _perform_interface_port_operations(self, context, port, network,
                                            is_delete=False):
         router_id = port.get('device_id')
-        if router_id == '':
+        if not router_id:
             return
         router = self.l3_plugin.get_router(context._plugin_context, router_id)
 
@@ -881,31 +881,32 @@ class APICMechanismDriver(api.MechanismDriver,
         if not net_info:
             return
 
-        if (self._is_nat_enabled_on_ext_net(ext_net) and
-                self._is_edge_nat(net_info)):
+        nat_enabled = self._is_nat_enabled_on_ext_net(ext_net)
+        is_edge_nat = nat_enabled and self._is_edge_nat(net_info)
+        if not nat_enabled or is_edge_nat:
             if self.per_tenant_context:
-                shadow_l3out = self.name_mapper.l3_out(
+                l3out = self.name_mapper.l3_out(
                     context, ext_net_id,
                     openstack_owner=router['tenant_id'])
-                router_tenant = self._get_tenant(router)
             else:
                 # There is exactly one shadow L3Out for all tenants since there
                 # is exactly one VRF for all tenants
-                shadow_l3out = self.name_mapper.l3_out(context, ext_net_id)
-                vrf_info = self._get_tenant_vrf(router['tenant_id'])
-                router_tenant = vrf_info['aci_tenant']
+                l3out = self.name_mapper.l3_out(context, ext_net_id)
 
-            shadow_l3out = self._get_shadow_name_for_nat(
-                shadow_l3out, is_edge_nat=True)
+            if is_edge_nat:
+                l3out = self._get_shadow_name_for_nat(l3out, is_edge_nat=True)
+            elif self._is_pre_existing(net_info):
+                l3out = self.name_mapper.pre_existing(context, ext_net['name'])
+
             bd_name = self.name_mapper.bridge_domain(
-                context, port['network_id'], openstack_owner=router_tenant)
+                context, network['id'],
+                openstack_owner=network['tenant_id'])
+            bd_tenant = self._get_network_aci_tenant(network)
 
             if is_delete:
-                self.apic_manager.unset_l3out_for_bd(
-                    router_tenant, bd_name, shadow_l3out)
+                self.apic_manager.unset_l3out_for_bd(bd_tenant, bd_name, l3out)
             else:
-                self.apic_manager.set_l3out_for_bd(
-                    router_tenant, bd_name, shadow_l3out)
+                self.apic_manager.set_l3out_for_bd(bd_tenant, bd_name, l3out)
 
     def _perform_gw_port_operations(self, context, port):
         router_id = port.get('device_id')
@@ -965,6 +966,8 @@ class APICMechanismDriver(api.MechanismDriver,
                         l3out_name_pre or l3out_name, cid,
                         external_epg=external_epg,
                         owner=l3out_tenant, transaction=trs)
+                self._manage_bd_to_l3out_link(
+                    context, router, l3out_name_pre or l3out_name)
 
     def _check_gw_port_operation(self, context, port):
         if port.get('device_owner') != n_constants.DEVICE_OWNER_ROUTER_GW:
@@ -1060,7 +1063,8 @@ class APICMechanismDriver(api.MechanismDriver,
         if port.get('device_owner') == n_constants.DEVICE_OWNER_ROUTER_GW:
             self._perform_gw_port_operations(context, port)
         elif port.get('device_owner') == n_constants.DEVICE_OWNER_ROUTER_INTF:
-            self._perform_interface_port_operations(context, port)
+            self._perform_interface_port_operations(context, port,
+                                                    context.network.current)
         elif (self._is_port_bound(port) and
               self._port_needs_static_path_binding(context)):
             self._perform_path_port_operations(context, port)
@@ -1077,6 +1081,9 @@ class APICMechanismDriver(api.MechanismDriver,
         l3out_name = self.name_mapper.l3_out(
             context, network['id'],
             openstack_owner=network['tenant_id'])
+        l3out_name_pre = (
+            self.name_mapper.pre_existing(context, network['name'])
+            if self._is_pre_existing(router_info) else None)
         router = self.l3_plugin.get_router(
             context._plugin_context, port.get('device_id'))
 
@@ -1089,6 +1096,9 @@ class APICMechanismDriver(api.MechanismDriver,
             context, port.get('device_id'),
             openstack_owner=router['tenant_id'])
 
+        self._manage_bd_to_l3out_link(
+            context, router, l3out_name_pre or l3out_name, unlink=True)
+
         # check if there are other routers
         is_last_gw_port = self._is_last_gw_port(context, port, router)
 
@@ -1096,10 +1106,7 @@ class APICMechanismDriver(api.MechanismDriver,
             if not self._is_pre_existing(router_info):
                 self.apic_manager.delete_external_epg_contract(
                     arouter_id, l3out_name, transaction=trs)
-                l3out_name_pre = None
             else:
-                l3out_name_pre = self.name_mapper.pre_existing(
-                    context, network['name'])
                 external_epg = self.name_mapper.pre_existing(
                     context,
                     router_info.get('external_epg', apic_manager.EXT_EPG))
@@ -1246,7 +1253,7 @@ class APICMechanismDriver(api.MechanismDriver,
             else:
                 self._delete_gw_port_nat_disabled(context)
         elif port.get('device_owner') == n_constants.DEVICE_OWNER_ROUTER_INTF:
-            self._perform_interface_port_operations(context, port,
+            self._perform_interface_port_operations(context, port, network,
                                                     is_delete=True)
 
         self._notify_ports_due_to_router_update(port)
@@ -1632,20 +1639,8 @@ class APICMechanismDriver(api.MechanismDriver,
                                       vrf, network,
                                       shadow_l3out, encap)
 
-                # queries all the BDs connected to this router
-                core_plugin = manager.NeutronManager.get_plugin()
-                router_intf_ports = core_plugin.get_ports(
-                    nctx.get_admin_context(),
-                    filters={'device_owner':
-                             [n_constants.DEVICE_OWNER_ROUTER_INTF],
-                             'device_id': [router['id']]})
-                for router_intf_port in router_intf_ports:
-                    bd_name = self.name_mapper.bridge_domain(
-                        context, router_intf_port['network_id'],
-                        openstack_owner=vrf_info['aci_tenant'])
-                    self.apic_manager.set_l3out_for_bd(
-                        vrf_info['aci_tenant'], bd_name, shadow_l3out,
-                        transaction=trs)
+                self._manage_bd_to_l3out_link(
+                    context, router, shadow_l3out, transaction=trs)
 
             self.apic_manager.ensure_external_epg_created(
                 shadow_l3out, external_epg=shadow_ext_epg,
@@ -1724,19 +1719,8 @@ class APICMechanismDriver(api.MechanismDriver,
                     network['name'], vrf_info['aci_name'],
                     vrf_info['aci_tenant'])
 
-                # queries all the BDs connected to this router
-                core_plugin = manager.NeutronManager.get_plugin()
-                router_intf_ports = core_plugin.get_ports(
-                    nctx.get_admin_context(),
-                    filters={'device_owner':
-                             [n_constants.DEVICE_OWNER_ROUTER_INTF],
-                             'device_id': [router['id']]})
-                for router_intf_port in router_intf_ports:
-                    bd_name = self.name_mapper.bridge_domain(
-                        context, router_intf_port['network_id'],
-                        openstack_owner=vrf_info['aci_tenant'])
-                    self.apic_manager.unset_l3out_for_bd(
-                        vrf_info['aci_tenant'], bd_name, shadow_l3out)
+                self._manage_bd_to_l3out_link(
+                    context, router, shadow_l3out, unlink=True)
 
     def _get_router_interface_subnets(self, context, router_ids):
         core_plugin = manager.NeutronManager.get_plugin()
@@ -2222,3 +2206,24 @@ class APICMechanismDriver(api.MechanismDriver,
                 LOG.info("Releasing dynamic-segment %(s)s for port %(p)s",
                          {'s': btm, 'p': port_context.current['id']})
                 port_context.release_dynamic_segment(btm[api.ID])
+
+    def _manage_bd_to_l3out_link(self, context, router, l3out, unlink=False,
+                                 transaction=None):
+        # Find networks connected to this router, set/unset the link from
+        # corresponding BDs to specified L3Out
+        core_plugin = manager.NeutronManager.get_plugin()
+        admin_ctx = nctx.get_admin_context()
+        router_intf_ports = core_plugin.get_ports(
+            admin_ctx,
+            filters={'device_owner': [n_constants.DEVICE_OWNER_ROUTER_INTF],
+                     'device_id': [router['id']]})
+        networks = core_plugin.get_networks(
+            admin_ctx,
+            filters={'id': [p['network_id'] for p in router_intf_ports]})
+        func = (self.apic_manager.unset_l3out_for_bd if unlink else
+                self.apic_manager.set_l3out_for_bd)
+        for net in networks:
+            bd_tenant_name = self._get_network_aci_tenant(net)
+            bd_name = self.name_mapper.bridge_domain(
+                context, net['id'], openstack_owner=net['tenant_id'])
+            func(bd_tenant_name, bd_name, l3out, transaction=transaction)

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -1339,9 +1339,10 @@ l3extRsPathL3OutAtt": {"attributes": {"ifInstT": "sub-interface", "encap": \
         self.driver.l3out_vlan_alloc.reserve_vlan = mock.Mock()
 
         manager.NeutronManager = mock.MagicMock()
-        manager.NeutronManager.get_plugin().get_ports.return_value = [
-            {'device_owner': u'network:router_interface',
-             'network_id': u'net_id'}]
+        manager.NeutronManager.get_plugin().get_networks.return_value = [
+            {'tenant_id': mocked.APIC_TENANT,
+             'name': mocked.APIC_NETWORK,
+             'id': u'net_id'}]
         self.driver.update_port_postcommit(port_ctx)
         mgr.get_router_contract.assert_called_once_with(
             self._scoped_name(port_ctx.current['device_id']),
@@ -1373,11 +1374,9 @@ l3extRsPathL3OutAtt": {"attributes": {"ifInstT": "sub-interface", "encap": \
         self.assertTrue(mgr.ensure_logical_node_profile_created.called)
         self.assertTrue(mgr.ensure_static_route_created.called)
 
-        bd_name = self._scoped_name('net_id',
-                                    tenant=self._tenant(ext_nat=True))
+        bd_name = self._scoped_name('net_id')
         mgr.set_l3out_for_bd.assert_called_once_with(
-            self._tenant(ext_nat=True), bd_name, l3out_name,
-            transaction=mock.ANY)
+            self._tenant(), bd_name, l3out_name, transaction=mock.ANY)
 
         expected_calls = [
             mock.call(
@@ -1405,12 +1404,25 @@ l3extRsPathL3OutAtt": {"attributes": {"ifInstT": "sub-interface", "encap": \
     def test_update_cross_tenant_edge_nat_gw_port_postcommit(self):
         self._test_update_edge_nat_gw_port_postcommit('admin_tenant')
 
-    def _test_update_edge_nat_interface_port_postcommit(
-        self, net_tenant=mocked.APIC_TENANT):
+    def _test_update_interface_port_postcommit(self, no_nat=False, pre=False,
+                                               net_tenant=None):
+        net_tenant = net_tenant or mocked.APIC_TENANT
+        if no_nat:
+            ext_net = mocked.APIC_NETWORK_NO_NAT
+            if pre:
+                self.external_network_dict[ext_net + '-name'][
+                    'preexisting'] = 'True'
+                self.driver._query_l3out_info = mock.Mock()
+                self.driver._query_l3out_info.return_value = {
+                    'l3out_tenant': self._tenant(),
+                    'vrf_name': self._network_vrf_name(),
+                    'vrf_tenant': self._tenant(vrf=True)}
+        else:
+            ext_net = mocked.APIC_NETWORK_EDGE_NAT
         net_ctx = self._get_network_context(net_tenant,
                                             'net_id',
                                             TEST_SEGMENT1)
-        port_ctx = self._get_port_context(mocked.APIC_TENANT,
+        port_ctx = self._get_port_context(net_tenant,
                                           'net_id',
                                           'vm1', net_ctx, HOST_ID1,
                                           interface=True)
@@ -1418,28 +1430,43 @@ l3extRsPathL3OutAtt": {"attributes": {"ifInstT": "sub-interface", "encap": \
             return_value={'id': mocked.APIC_ROUTER,
                           'tenant_id': mocked.APIC_TENANT,
                           'external_gateway_info':
-                              {'network_id': mocked.APIC_NETWORK_EDGE_NAT,
+                              {'network_id': ext_net,
                                'external_fixed_ips': []}})
         port_ctx._plugin.get_network = mock.Mock(
-            return_value={'name': mocked.APIC_NETWORK_EDGE_NAT + '-name',
+            return_value={'name': ext_net + '-name',
                           'router:external': True})
 
         self.driver.update_port_postcommit(port_ctx)
 
         l3out_name = (self.driver.per_tenant_context and
-                      self._scoped_name(mocked.APIC_NETWORK_EDGE_NAT) or
-                      mocked.APIC_NETWORK_EDGE_NAT)
-        l3out_name = "Auto-%s" % l3out_name
-        bd_name = self._scoped_name('net_id',
-                                    tenant=self._tenant(ext_nat=True))
+                      self._scoped_name(ext_net) or ext_net)
+        if not no_nat:
+            l3out_name = "Auto-%s" % l3out_name
+        elif pre:
+            l3out_name = self._scoped_name(ext_net + '-name', preexisting=True)
+        bd_name = self._scoped_name('net_id', tenant=net_tenant)
         self.driver.apic_manager.set_l3out_for_bd.assert_called_once_with(
-            self._tenant(ext_nat=True), bd_name, l3out_name)
+            self._tenant(neutron_tenant=net_tenant), bd_name, l3out_name)
 
     def test_update_edge_nat_interface_port_postcommit(self):
-        self._test_update_edge_nat_interface_port_postcommit()
+        self._test_update_interface_port_postcommit()
 
     def test_update_cross_tenant_edge_nat_interface_port_postcommit(self):
-        self._test_update_edge_nat_interface_port_postcommit('admin_tenant')
+        self._test_update_interface_port_postcommit('another')
+
+    def test_update_no_nat_interface_port_postcommit(self):
+        self._test_update_interface_port_postcommit(no_nat=True)
+
+    def test_update_cross_tenant_no_nat_interface_port_postcommit(self):
+        self._test_update_interface_port_postcommit(no_nat=True,
+                                                    net_tenant='another')
+
+    def test_update_pre_no_nat_interface_port_postcommit(self):
+        self._test_update_interface_port_postcommit(no_nat=True, pre=True)
+
+    def test_update_cross_tenant_pre_no_nat_interface_port_postcommit(self):
+        self._test_update_interface_port_postcommit(
+            no_nat=True, pre=True, net_tenant='another')
 
     def _test_update_pre_edge_nat_gw_port_postcommit(
         self, net_tenant=mocked.APIC_TENANT):
@@ -1520,9 +1547,10 @@ tt':
         self.driver.l3out_vlan_alloc.reserve_vlan.return_value = 999
 
         manager.NeutronManager = mock.MagicMock()
-        manager.NeutronManager.get_plugin().get_ports.return_value = [
-            {'device_owner': u'network:router_interface',
-             'network_id': u'net_id'}]
+        manager.NeutronManager.get_plugin().get_networks.return_value = [
+            {'tenant_id': mocked.APIC_TENANT,
+             'name': mocked.APIC_NETWORK,
+             'id': u'net_id'}]
 
         self.driver.update_port_postcommit(port_ctx)
         mgr.get_router_contract.assert_called_once_with(
@@ -1558,10 +1586,8 @@ tt':
                                                        preexisting=True),
             owner=self._tenant(ext_nat=True), transaction=mock.ANY)
 
-        bd_name = self._scoped_name('net_id',
-                                    tenant=self._tenant(ext_nat=True))
         mgr.set_l3out_for_bd.assert_called_once_with(
-            self._tenant(ext_nat=True), bd_name, l3out_name,
+            self._tenant(), self._scoped_name('net_id'), l3out_name,
             transaction=mock.ANY)
 
         expected_calls = [
@@ -1681,6 +1707,16 @@ tt':
             'l3out_tenant': l3out_tenant,
             'vrf_name': ctx_name,
             'vrf_tenant': self._tenant(vrf=True)}
+        nets = [
+            {'tenant_id': mocked.APIC_TENANT + '1',
+             'name': mocked.APIC_NETWORK,
+             'id': 'net_id1'},
+            {'tenant_id': mocked.APIC_TENANT + '2',
+             'name': mocked.APIC_NETWORK,
+             'id': 'net_id2'}]
+        manager.NeutronManager = mock.MagicMock()
+        manager.NeutronManager.get_plugin().get_networks.return_value = nets
+
         self.driver.update_port_postcommit(port_ctx)
         mgr.get_router_contract.assert_called_once_with(
             self._scoped_name(port_ctx.current['device_id']),
@@ -1689,15 +1725,15 @@ tt':
         self.assertFalse(mgr.ensure_external_routed_network_created.called)
         self.assertFalse(mgr.ensure_external_epg_created.called)
 
+        l3out_name = self._scoped_name(net_ctx.current['name'],
+                                       preexisting=True)
         mgr.set_context_for_external_routed_network.assert_called_once_with(
-            l3out_tenant,
-            self._scoped_name(net_ctx.current['name'], preexisting=True),
-            self._network_vrf_name(),
+            l3out_tenant, l3out_name, self._network_vrf_name(),
             transaction=mock.ANY)
 
         expected_calls = [
             mock.call(
-                self._scoped_name(net_ctx.current['name'], preexisting=True),
+                l3out_name,
                 mgr.get_router_contract.return_value,
                 external_epg=self._scoped_name(mocked.APIC_EXT_EPG,
                                                preexisting=True),
@@ -1708,8 +1744,7 @@ tt':
 
         expected_calls = [
             mock.call(
-                self._scoped_name(net_ctx.current['name'], preexisting=True),
-                mgr.get_router_contract.return_value,
+                l3out_name, mgr.get_router_contract.return_value,
                 external_epg=self._scoped_name(mocked.APIC_EXT_EPG,
                                                preexisting=True),
                 owner=l3out_tenant, transaction=mock.ANY)]
@@ -1717,6 +1752,15 @@ tt':
             expected_calls,
             mgr.ensure_external_epg_provided_contract.call_args_list)
         self.assertFalse(mgr.set_contract_for_epg.called)
+
+        expected_l3out_bd_calls = [
+            mock.call(self._tenant(neutron_tenant=n['tenant_id']),
+                      self._scoped_name(n['id'], tenant=n['tenant_id']),
+                      l3out_name,
+                      transaction=mock.ANY)
+            for n in nets]
+        self._check_call_list(expected_l3out_bd_calls,
+                              mgr.set_l3out_for_bd.call_args_list)
 
     def test_update_pre_no_nat_gw_port_postcommit_tenant(self):
         self._test_update_pre_no_nat_gw_port_postcommit(self._tenant())
@@ -1766,9 +1810,10 @@ tt':
         self.driver._delete_path_if_last = mock.Mock()
         self.driver.l3out_vlan_alloc.release_vlan = mock.Mock()
         manager.NeutronManager = mock.MagicMock()
-        manager.NeutronManager.get_plugin().get_ports.return_value = [
-            {'device_owner': u'network:router_interface',
-             'network_id': u'net_id'}]
+        manager.NeutronManager.get_plugin().get_networks.return_value = [
+            {'tenant_id': mocked.APIC_TENANT,
+             'name': mocked.APIC_NETWORK,
+             'id': 'net_id'}]
         self.driver.delete_port_postcommit(port_ctx)
         mgr = self.driver.apic_manager
         mgr.delete_external_routed_network.assert_called_once_with(
@@ -1784,10 +1829,9 @@ tt':
                       self._scoped_name(mocked.APIC_NETWORK_EDGE_NAT) or
                       mocked.APIC_NETWORK_EDGE_NAT)
         l3out_name = "Auto-%s" % l3out_name
-        bd_name = self._scoped_name('net_id',
-                                    tenant=self._tenant(ext_nat=True))
+        bd_name = self._scoped_name('net_id')
         mgr.unset_l3out_for_bd.assert_called_once_with(
-            self._tenant(ext_nat=True), bd_name, l3out_name)
+            self._tenant(), bd_name, l3out_name, transaction=mock.ANY)
 
     def test_delete_pre_edge_nat_gw_port_postcommit(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,
@@ -1799,9 +1843,10 @@ tt':
         self.driver._delete_path_if_last = mock.Mock()
         self.driver.l3out_vlan_alloc.release_vlan = mock.Mock()
         manager.NeutronManager = mock.MagicMock()
-        manager.NeutronManager.get_plugin().get_ports.return_value = [
-            {'device_owner': u'network:router_interface',
-             'network_id': u'net_id'}]
+        manager.NeutronManager.get_plugin().get_networks.return_value = [
+            {'tenant_id': mocked.APIC_TENANT,
+             'name': mocked.APIC_NETWORK,
+             'id': 'net_id'}]
         self.driver.delete_port_postcommit(port_ctx)
         mgr = self.driver.apic_manager
         mgr.delete_external_routed_network.assert_called_once_with(
@@ -1817,10 +1862,9 @@ tt':
                       self._scoped_name(mocked.APIC_NETWORK_PRE_EDGE_NAT) or
                       mocked.APIC_NETWORK_PRE_EDGE_NAT)
         l3out_name = "Auto-%s" % l3out_name
-        bd_name = self._scoped_name('net_id',
-                                    tenant=self._tenant(ext_nat=True))
+        bd_name = self._scoped_name('net_id')
         mgr.unset_l3out_for_bd.assert_called_once_with(
-            self._tenant(ext_nat=True), bd_name, l3out_name)
+            self._tenant(), bd_name, l3out_name, transaction=mock.ANY)
 
     def test_delete_edge_nat_interface_port_postcommit(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,
@@ -1846,10 +1890,9 @@ tt':
                       self._scoped_name(mocked.APIC_NETWORK_EDGE_NAT) or
                       mocked.APIC_NETWORK_EDGE_NAT)
         l3out_name = "Auto-%s" % l3out_name
-        bd_name = self._scoped_name('net_id',
-                                    tenant=self._tenant(ext_nat=True))
+        bd_name = self._scoped_name('net_id')
         self.driver.apic_manager.unset_l3out_for_bd.assert_called_once_with(
-            self._tenant(ext_nat=True), bd_name, l3out_name)
+            self._tenant(), bd_name, l3out_name)
 
     def test_update_no_nat_gw_port_postcommit(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,
@@ -1861,30 +1904,48 @@ tt':
         mgr = self.driver.apic_manager
         mgr.get_router_contract.return_value = mocked.FakeDbContract(
             mocked.APIC_CONTRACT)
+        nets = [
+            {'tenant_id': mocked.APIC_TENANT + '1',
+             'name': mocked.APIC_NETWORK,
+             'id': 'net_id1'},
+            {'tenant_id': mocked.APIC_TENANT + '2',
+             'name': mocked.APIC_NETWORK,
+             'id': 'net_id2'}]
+        manager.NeutronManager = mock.MagicMock()
+        manager.NeutronManager.get_plugin().get_networks.return_value = nets
 
         self.driver.update_port_postcommit(port_ctx)
+        l3out_name = self._scoped_name(mocked.APIC_NETWORK_NO_NAT)
         mgr.get_router_contract.assert_called_once_with(
             self._scoped_name(port_ctx.current['device_id']),
             owner=self._router_tenant())
 
         mgr.set_context_for_external_routed_network.assert_called_once_with(
-            self._tenant(), self._scoped_name(mocked.APIC_NETWORK_NO_NAT),
+            self._tenant(), l3out_name,
             self._network_vrf_name(),
             transaction=mock.ANY)
 
         mgr.ensure_external_epg_consumed_contract.assert_called_once_with(
-            self._scoped_name(mocked.APIC_NETWORK_NO_NAT),
+            l3out_name,
             mgr.get_router_contract.return_value,
             external_epg=mocked.APIC_EXT_EPG, transaction=mock.ANY,
             owner=self._tenant())
 
         mgr.ensure_external_epg_provided_contract.assert_called_once_with(
-            self._scoped_name(mocked.APIC_NETWORK_NO_NAT),
+            l3out_name,
             mgr.get_router_contract.return_value,
             external_epg=mocked.APIC_EXT_EPG, transaction=mock.ANY,
             owner=self._tenant())
 
         self.assertFalse(mgr.set_contract_for_epg.called)
+        expected_l3out_bd_calls = [
+            mock.call(self._tenant(neutron_tenant=n['tenant_id']),
+                      self._scoped_name(n['id'], tenant=n['tenant_id']),
+                      l3out_name,
+                      transaction=mock.ANY)
+            for n in nets]
+        self._check_call_list(expected_l3out_bd_calls,
+                              mgr.set_l3out_for_bd.call_args_list)
 
     def test_delete_unrelated_gw_port_postcommit(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,
@@ -1937,6 +1998,15 @@ tt':
                 'l3out_tenant': self._tenant(),
                 'vrf_name': self._network_vrf_name(),
                 'vrf_tenant': self._tenant(vrf=True)}
+        nets = [
+            {'tenant_id': mocked.APIC_TENANT + '1',
+             'name': mocked.APIC_NETWORK,
+             'id': 'net_id1'},
+            {'tenant_id': mocked.APIC_TENANT + '2',
+             'name': mocked.APIC_NETWORK,
+             'id': 'net_id2'}]
+        manager.NeutronManager = mock.MagicMock()
+        manager.NeutronManager.get_plugin().get_networks.return_value = nets
 
         self.driver.delete_port_postcommit(port_ctx)
 
@@ -1970,6 +2040,14 @@ tt':
                 transaction=mock.ANY)
 
         self.assertFalse(mgr.delete_external_routed_network.called)
+        expected_l3out_bd_calls = [
+            mock.call(self._tenant(neutron_tenant=n['tenant_id']),
+                      self._scoped_name(n['id'], tenant=n['tenant_id']),
+                      l3out_name,
+                      transaction=mock.ANY)
+            for n in nets]
+        self._check_call_list(expected_l3out_bd_calls,
+                              mgr.unset_l3out_for_bd.call_args_list)
 
     def test_delete_no_nat_gw_port_postcommit(self):
         self._test_delete_no_nat_gw_port_postcommit(False)


### PR DESCRIPTION
Even with NAT disabled, it is useful to connected the
private BD to the L3Out so that private subnets are
advertised through dynamic routing protocols.

In addition, also fixed bugs in code-path for edge-NAT
that sets up the BD-to-L3Out link.

Partially-Closes noironetworks/support#109

Signed-off-by: Amit Bose amitbose@gmail.com
