### PR TITLE
Do not use transaction while setting BD to Auto-l3out

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -1642,7 +1642,7 @@ class APICMechanismDriver(api.MechanismDriver,
                                       shadow_l3out, encap)
 
                 self._manage_bd_to_l3out_link(
-                    context, router, shadow_l3out, transaction=trs)
+                    context, router, shadow_l3out)
 
             self.apic_manager.ensure_external_epg_created(
                 shadow_l3out, external_epg=shadow_ext_epg,


### PR DESCRIPTION
1. This is to avoid ApicInvalidTransactionMultipleRoot exception in
   some certain mode.
