### PR TITLE
[VRF per router] Tie VRF lifetime to that of the router

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -938,22 +938,7 @@ class APICMechanismDriver(api.MechanismDriver,
                         bd_tenant, bd_name,
                         self._get_network_vrf(context, network)['aci_name'],
                         transaction=trs)
-                    # delete VRF if last interface port
-                    intf_port_filter = {
-                        'device_owner': [n_constants.DEVICE_OWNER_ROUTER_INTF],
-                        'device_id': [router_id]}
-                    other_ports = context._plugin.get_ports(
-                        context._plugin_context, filters=intf_port_filter)
-                    other_ports = [p for p in other_ports
-                                   if p['id'] != port['id']]
-                    if not other_ports:
-                        self.apic_manager.ensure_context_deleted(
-                            owner=vrf_info['aci_tenant'],
-                            ctx_id=vrf_info['aci_name'], transaction=trs)
                 else:
-                    self.apic_manager.ensure_context_enforced(
-                        owner=vrf_info['aci_tenant'],
-                        ctx_id=vrf_info['aci_name'], transaction=trs)
                     self.apic_manager.set_context_for_bd(
                         bd_tenant, bd_name, vrf_info['aci_name'],
                         transaction=trs)
@@ -2358,3 +2343,17 @@ class APICMechanismDriver(api.MechanismDriver,
         vrf_name = ('%s-%s' % (tenant, router['id'])
                     if self.single_tenant_mode else router['id'])
         return {'aci_name': vrf_name, 'aci_tenant': self._get_tenant(router)}
+
+    def create_vrf_per_router(self, router, transaction=None):
+        if self._is_vrf_per_router(router):
+            vrf_info = self._get_router_vrf(router)
+            self.apic_manager.ensure_context_enforced(
+                owner=vrf_info['aci_tenant'], ctx_id=vrf_info['aci_name'],
+                transaction=transaction)
+
+    def delete_vrf_per_router(self, router, transaction=None):
+        if self._is_vrf_per_router(router):
+            vrf_info = self._get_router_vrf(router)
+            self.apic_manager.ensure_context_deleted(
+                owner=vrf_info['aci_tenant'], ctx_id=vrf_info['aci_name'],
+                transaction=transaction)

--- a/apic_ml2/neutron/services/l3_router/apic_driver.py
+++ b/apic_ml2/neutron/services/l3_router/apic_driver.py
@@ -154,6 +154,9 @@ class ApicL3Driver(apic_driver_api.ApicL3DriverBase):
         self._plugin._core_plugin.update_port_status(
             context, port_id, q_const.PORT_STATUS_DOWN)
 
+    def create_router_postcommit(self, context, router):
+        self.aci_mech_driver.create_vrf_per_router(router)
+
     # TODO(tbachman): move to postcommit?
     def delete_router_precommit(self, context, router_id):
         context._plugin = self._plugin
@@ -162,6 +165,7 @@ class ApicL3Driver(apic_driver_api.ApicL3DriverBase):
             arouter_id = router_id and self.name_mapper.router(
                 ctx, router['id'], openstack_owner=router['id'])
         self.manager.delete_router(arouter_id)
+        self.aci_mech_driver.delete_vrf_per_router(router)
 
     def update_router_postcommit(self, context, router):
         context._plugin = self._plugin

--- a/apic_ml2/neutron/services/l3_router/apic_driver_api.py
+++ b/apic_ml2/neutron/services/l3_router/apic_driver_api.py
@@ -23,6 +23,14 @@ class ApicL3DriverBase(object):
        API call.  This allows the driver to be used by other Layer 3 service
        plugins (e.g. the Cisco Router Service Plugin).
        """
+    def create_router_postcommit(self, context, router):
+        """Post-DB operation for create_router API
+
+        This should be called after the DB operation to the
+        router has been performed.
+        """
+        pass
+
     def update_router_postcommit(self, context, router):
         """Post-DB operation for update_router API
 

--- a/apic_ml2/neutron/services/l3_router/l3_apic.py
+++ b/apic_ml2/neutron/services/l3_router/l3_apic.py
@@ -74,8 +74,9 @@ class ApicL3ServicePlugin(common_db_mixin.CommonDbMixin,
                 LOG.exception(_("An exception occurred while creating "
                                 "the router: %s"), router)
                 self.delete_router(context, router_db.id)
-
-        return self._make_router_dict(router_db)
+        result = self._make_router_dict(router_db)
+        self._apic_driver.create_router_postcommit(context, result)
+        return result
 
     def update_router(self, context, id, router):
         result = super(ApicL3ServicePlugin, self).update_router(context,

--- a/apic_ml2/neutron/tests/unit/services/l3_router/test_apic_driver.py
+++ b/apic_ml2/neutron/tests/unit/services/l3_router/test_apic_driver.py
@@ -169,11 +169,21 @@ class TestCiscoApicL3Driver(testlib_api.SqlTestCase,
                                                    owner=self._tenant(),
                                                    transaction='transaction')
 
+    def test_create_router_postcommit(self):
+        rtr = {'id': ROUTER, 'tenant_id': TENANT, 'admin_state_up': True}
+        apic_driver = self.plugin._apic_driver
+        apic_driver.create_router_postcommit(self.context, rtr)
+        md = apic_driver._aci_mech_driver
+        md.create_vrf_per_router.assert_called_once_with(rtr)
+
     def test_delete_router_precommit(self):
         apic_driver = self.plugin._apic_driver
         mgr = apic_driver.manager
         apic_driver.delete_router_precommit(self.context, ROUTER)
         mgr.delete_router.assert_called_once_with(mocked.APIC_ROUTER)
+        md = apic_driver._aci_mech_driver
+        md.delete_vrf_per_router.assert_called_once_with(
+            {'id': ROUTER, 'tenant_id': TENANT, 'admin_state_up': True})
 
     def _test_add_router_interface_postcommit(self, interface_info):
         apic_driver = self.plugin._apic_driver


### PR DESCRIPTION
In vrf-per-router mode, when a router is created/deleted,
the corresponding VRF will also be created/removed.
This allows us to keep the code simple instead
of creating the VRF when the router is used and
removing it when the router is not being used.

Closes noironetworks/support#253

Signed-off-by: Amit Bose amitbose@gmail.com
