### PR TITLE
Fix sync stale networks

### DIFF
--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -871,6 +871,11 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
             tenant_id='onetenant', name=acst.APIC_SYNC_NETWORK,
             expected_res_status=201)
         self.assertEqual({}, net['network'])
+        # Net shouldn't exist
+        nets = self.driver.db_plugin.get_networks(
+            context.get_admin_context(),
+            filters={'name': [acst.APIC_SYNC_NETWORK]})
+        self.assertEqual(0, len(nets))
 
     def test_request_endpoint_details(self):
         net = self.create_network(expected_res_status=201)['network']


### PR DESCRIPTION
After running apic neutron-sync a network gets created with the
synchronization reserved name. This is not expected, make sure
that the plugin cleans such stale networks.
