### PR TITLE
[VRF per router] Update all networks port on router change

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -1879,14 +1879,28 @@ class APICMechanismDriver(api.MechanismDriver,
                     for x in port.get('fixed_ips', [])])
 
     def _notify_ports_due_to_router_update(self, router_port):
+        core_plugin = manager.NeutronManager.get_plugin()
+        admin_ctx = nctx.get_admin_context()
+        dev_owner = router_port['device_owner']
+        skip = [n_constants.DEVICE_OWNER_ROUTER_INTF,
+                n_constants.DEVICE_OWNER_ROUTER_GW]
+
+        # With VRF-per-router, update all ports in the network when
+        # there is an update to the router interface port
+        if (dev_owner == n_constants.DEVICE_OWNER_ROUTER_INTF and
+                self._is_vrf_per_router(router_port)):
+            ports = core_plugin.get_ports(
+                admin_ctx,
+                filters={'network_id': [router_port['network_id']]})
+            for p in ports:
+                if p['device_owner'] not in skip and self._is_port_bound(p):
+                    self.notifier.port_update(admin_ctx, p)
+            return
+
         # Find ports whose DNAT/SNAT info may be affected due to change
         # in a router's connectivity to external/tenant network.
         if not self.nat_enabled:
             return
-        dev_owner = router_port['device_owner']
-        admin_ctx = nctx.get_admin_context()
-        skip = [n_constants.DEVICE_OWNER_ROUTER_INTF,
-                n_constants.DEVICE_OWNER_ROUTER_GW]
         if dev_owner == n_constants.DEVICE_OWNER_ROUTER_INTF:
             subnet_ids = self._get_port_subnets(router_port)
         elif dev_owner == n_constants.DEVICE_OWNER_ROUTER_GW:
@@ -1894,7 +1908,7 @@ class APICMechanismDriver(api.MechanismDriver,
                 admin_ctx, [router_port['device_id']])
         else:
             return
-        core_plugin = manager.NeutronManager.get_plugin()
+
         subnets = core_plugin.get_subnets(
             admin_ctx, filters={'id': list(subnet_ids)})
         nets = set([x['network_id'] for x in subnets])

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -3469,6 +3469,51 @@ class ApicML2IntegratedTestCaseSingleVRF(ApicML2IntegratedTestCase):
                 context.get_admin_context(), router['id'],
                 {'port_id': p1['port']['id']})
 
+    def test_vrf_per_router_intf_update(self):
+        self.driver.vrf_per_router_tenants.append(mocked.APIC_TENANT)
+        net = self.create_network(tenant_id=mocked.APIC_TENANT)['network']
+        sub1 = self.create_subnet(
+            network_id=net['id'], cidr='192.168.0.0/24',
+            tenant_id=mocked.APIC_TENANT, ip_version=4)
+        sub2 = self.create_subnet(
+            network_id=net['id'], cidr='192.168.1.0/24',
+            tenant_id=mocked.APIC_TENANT, ip_version=4)
+        router = self.create_router(api=self.ext_api,
+                                    tenant_id=mocked.APIC_TENANT)['router']
+        with self.port(subnet=sub1,
+                       fixed_ips=[{'subnet_id': sub1['subnet']['id']}],
+                       tenant_id=mocked.APIC_TENANT) as p:
+            p1 = p['port']
+        with self.port(subnet=sub2,
+                       fixed_ips=[{'subnet_id': sub2['subnet']['id']}],
+                       tenant_id=mocked.APIC_TENANT) as p:
+            p2 = p['port']
+
+        self.mgr.add_router_interface = mock.Mock()
+        self.driver.notifier.port_update = mock.Mock()
+
+        self._register_agent('h1')
+        self._bind_port_to_host(p1['id'], 'h1')
+        self._bind_port_to_host(p2['id'], 'h1')
+
+        ctx = context.Context(user_id=None, tenant_id=mocked.APIC_TENANT)
+
+        self.driver.notifier.port_update.reset_mock()
+        self.l3_plugin.add_router_interface(
+            ctx, router['id'], {'subnet_id': sub1['subnet']['id']})
+        updates = sorted(set(
+            [pt[0][1]['id']
+             for pt in self.driver.notifier.port_update.call_args_list]))
+        self.assertEqual(sorted([p1['id'], p2['id']]), updates)
+
+        self.driver.notifier.port_update.reset_mock()
+        self.l3_plugin.remove_router_interface(
+            ctx, router['id'], {'subnet_id': sub1['subnet']['id']})
+        updates = sorted(set(
+            [pt[0][1]['id']
+             for pt in self.driver.notifier.port_update.call_args_list]))
+        self.assertEqual(sorted([p1['id'], p2['id']]), updates)
+
 
 class ApicML2IntegratedTestCaseSingleTenant(ApicML2IntegratedTestCase):
 


### PR DESCRIPTION
If the router interface port attached to a subnet changes,
notify all ports in network (as opposed to just the subnet)
so that VRF information will be recalculated for all the
endpoints.

Closes noironetworks/support#267

Signed-off-by: Amit Bose amitbose@gmail.com
