### PR TITLE
Secure port binding feature

### DIFF
--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -62,6 +62,7 @@ from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import (
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import (
     rpc as mech_rpc)
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import constants as acst
+from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import nova_client
 from apic_ml2.neutron.services.l3_router import apic_driver as driver
 from apic_ml2.neutron.tests.unit.ml2.drivers.cisco.apic import (
     test_cisco_apic_common as mocked)
@@ -981,6 +982,40 @@ default = private
             network_id=net2['id'], cidr='10.10.10.0/24', ip_version=4,
             expected_res_status=500)
         self.assertEqual('MechanismDriverError', res['NeutronError']['type'])
+
+    def test_allow_vm_names(self):
+        class MockVM(object):
+            def __init__(self, vm_name):
+                self.name = vm_name
+        self.driver._agent_bind_port = mock.Mock()
+
+        cons_data = """
+[common/shared]
+allow_vm_names = secure_vm*, safe_vm*
+            """
+        self.driver.net_cons.source.last_refresh_time = 0
+        with open(self.cons_file_name, 'w') as fd:
+            fd.write(cons_data)
+
+        net = self.create_network(
+            name='net', tenant_id=mocked.APIC_TENANT,
+            expected_res_status=201)['network']
+        sub = self.create_subnet(
+            tenant_id=mocked.APIC_TENANT,
+            network_id=net['id'], cidr='192.168.0.0/24', ip_version=4)
+
+        nova_client.NovaClient().get_server = mock.Mock(
+            return_value=MockVM('bad_vm1'))
+        with self.port(subnet=sub, tenant_id=mocked.APIC_TENANT) as p1:
+            self._bind_port_to_host(p1['port']['id'], 'h1')
+        self.assertFalse(self.driver._agent_bind_port.called)
+
+        # try one more time with different vm name
+        nova_client.NovaClient().get_server = mock.Mock(
+            return_value=MockVM('safe_vm1'))
+        with self.port(subnet=sub, tenant_id=mocked.APIC_TENANT) as p2:
+            self._bind_port_to_host(p2['port']['id'], 'h1')
+        self.assertTrue(self.driver._agent_bind_port.called)
 
 
 class MechanismRpcTestCase(ApicML2IntegratedTestBase):

--- a/etc/neutron/plugins/ml2/cisco_apic_network_constraints.ini
+++ b/etc/neutron/plugins/ml2/cisco_apic_network_constraints.ini
@@ -53,4 +53,14 @@
 # [tenant1]
 # private = 50.50.50.0/26
 # default = deny
-
+#
+#
+# We also use this same file to enforce the secure port binding
+# regex rules against certain APIC vrf. A vrf section looks like:
+# [APIC-tenant-name/APIC-vrf-name]
+# allow_vm_names = <regex1>, <regex2>, ...
+#
+# Example:
+#
+# [_openstack1_coke/_openstack1_shared]
+# allow_vm_names = secure_vm*, safe_vm*


### PR DESCRIPTION
1. piggy-back the network constraint config file to enforce this feature.
2. enforce this while doing the port binding in MD.
3. add the corresponding UTs and sample ini file.
