### PR TITLE
Add support for L2 only mode

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/config.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/config.py
@@ -96,6 +96,10 @@ apic_opts = [
     cfg.StrOpt('network_constraints_filename',
                default=None,
                help=_("Complete path of file containing network constraints")),
+    cfg.BoolOpt('l3_cisco_router_plugin',
+                default=False,
+                help=_("Set to true when using the Cisco Router "
+                       "plugin for L3")),
     cfg.ListOpt('vrf_per_router_tenants',
                 default=[],
                 help=_('Projects in which each router maps to a '

--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -241,6 +241,13 @@ class APICMechanismDriver(api.MechanismDriver,
         return _apic_driver_instance
 
     @property
+    def fabric_l3(self):
+        if self._fabric_l3 is None:
+            self._fabric_l3 = self._cisco_l3 or hasattr(self._l3_plugin,
+                                                        '_apic_driver')
+        return self._fabric_l3
+
+    @property
     def l3_plugin(self):
         if not self._l3_plugin:
             plugins = manager.NeutronManager.get_service_plugins()
@@ -457,6 +464,8 @@ class APICMechanismDriver(api.MechanismDriver,
         _apic_driver_instance = self
         self._l3_plugin = None
         self._db_plugin = None
+        self._fabric_l3 = None
+        self._cisco_l3 = cfg.CONF.ml2_cisco_apic.l3_cisco_router_plugin
         self.attestator = attestation.EndpointAttestator(self.apic_manager)
         net_cons_source = cfg.CONF.ml2_cisco_apic.network_constraints_filename
         if net_cons_source is not None:
@@ -1192,7 +1201,11 @@ class APICMechanismDriver(api.MechanismDriver,
     def _perform_port_operations(self, context):
         # Get port
         port = context.current
-        if port.get('device_owner') == n_constants.DEVICE_OWNER_ROUTER_GW:
+        if not self.fabric_l3:
+            if (self._is_port_bound(port) and
+                    self._port_needs_static_path_binding(context)):
+                self._perform_path_port_operations(context, port)
+        elif port.get('device_owner') == n_constants.DEVICE_OWNER_ROUTER_GW:
             self._perform_gw_port_operations(context, port)
         elif port.get('device_owner') == n_constants.DEVICE_OWNER_ROUTER_INTF:
             self._perform_interface_port_operations(context, port,
@@ -1324,6 +1337,8 @@ class APICMechanismDriver(api.MechanismDriver,
                     self.notifier.port_update(context._plugin_context, port)
 
     def create_port_precommit(self, context):
+        if not self.fabric_l3:
+            return
         port = context.current
         network = context.network.current
         self._check_gw_port_operation(context, port)
@@ -1346,6 +1361,8 @@ class APICMechanismDriver(api.MechanismDriver,
                 context, context.current['network_id'], subs)
 
     def update_port_precommit(self, context):
+        if not self.fabric_l3:
+            return
         self._check_gw_port_operation(context, context.current)
         self._check_interface_port_operation(context, context.current)
 
@@ -1387,14 +1404,16 @@ class APICMechanismDriver(api.MechanismDriver,
                 self._is_port_bound(port) and context.bottom_bound_segment):
             self._delete_path_if_last(context)
             self._release_dynamic_segment(context)
-        if port.get('device_owner') == n_constants.DEVICE_OWNER_ROUTER_GW:
-            if self._is_nat_enabled_on_ext_net(network):
-                self._delete_shadow_ext_net_for_nat(context, port, network)
-            else:
-                self._delete_gw_port_nat_disabled(context)
-        elif port.get('device_owner') == n_constants.DEVICE_OWNER_ROUTER_INTF:
-            self._perform_interface_port_operations(context, port, network,
-                                                    is_delete=True)
+        if self.fabric_l3:
+            owner = port.get('device_owner')
+            if owner == n_constants.DEVICE_OWNER_ROUTER_GW:
+                if self._is_nat_enabled_on_ext_net(network):
+                    self._delete_shadow_ext_net_for_nat(context, port, network)
+                else:
+                    self._delete_gw_port_nat_disabled(context)
+            elif owner == n_constants.DEVICE_OWNER_ROUTER_INTF:
+                self._perform_interface_port_operations(context, port, network,
+                                                        is_delete=True)
 
         self._notify_ports_due_to_router_update(port)
         if (port.get('binding:vif_details') and
@@ -1432,7 +1451,7 @@ class APICMechanismDriver(api.MechanismDriver,
                     app_profile_name=self._get_network_app_profile(
                         context.current), bd_name=bd_name,
                     transaction=trs)
-        else:
+        elif self.fabric_l3:
             self._create_real_external_network(context, context.current)
 
     def update_network_postcommit(self, context):
@@ -1487,6 +1506,8 @@ class APICMechanismDriver(api.MechanismDriver,
                         subnet_cidr=cidr, ext_net=network['name'])
 
     def create_subnet_postcommit(self, context):
+        if not self.fabric_l3:
+            return
         info = self._get_subnet_info(context, context.current)
         if info:
             tenant_id, network_id, gateway_ip = info
@@ -1497,7 +1518,8 @@ class APICMechanismDriver(api.MechanismDriver,
         self.notify_subnet_update(context.current)
 
     def update_subnet_postcommit(self, context):
-        if context.current['gateway_ip'] != context.original['gateway_ip']:
+        if self.fabric_l3 and (context.current['gateway_ip'] !=
+                               context.original['gateway_ip']):
             with self.apic_manager.apic.transaction() as trs:
                 info = self._get_subnet_info(context, context.original)
                 if info:
@@ -1527,7 +1549,7 @@ class APICMechanismDriver(api.MechanismDriver,
 
     def delete_subnet_postcommit(self, context):
         info = self._get_subnet_info(context, context.current)
-        if info:
+        if self.fabric_l3 and info:
             tenant_id, network_id, gateway_ip = info
             self.apic_manager.ensure_subnet_deleted_on_apic(
                 tenant_id, network_id, gateway_ip)

--- a/apic_ml2/neutron/services/l3_router/l3_apic.py
+++ b/apic_ml2/neutron/services/l3_router/l3_apic.py
@@ -35,6 +35,10 @@ class ApicL3ServicePlugin(common_db_mixin.CommonDbMixin,
     def __init__(self):
         super(ApicL3ServicePlugin, self).__init__()
         self.synchronizer = None
+        # NB(tbachman): the mechanism driver depends on the existence
+        # of the _apic_driver member. If this member is changed or
+        # deleted, the code in the mechanism driver should be changed
+        # as well.
         self._apic_driver = apic_driver.ApicL3Driver(self)
 
     def _update_router_gw_info(self, context, router_id, info, router=None):

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -3671,6 +3671,7 @@ class TestApicML2IntegratedPhysicalNode(ApicML2IntegratedTestBase):
             'physnet1': {'hosts': set(['fw-app-01', 'lb-app-01'])}}
         self.mgr.ensure_path_created_for_port = mock.Mock()
         self.mgr.ensure_path_deleted_for_port = mock.Mock()
+        self.mgr.ensure_subnet_created_on_apic = mock.Mock()
         self._register_agent('fw-app-01')
         self._register_agent('lb-app-01')
         self.expected_bound_driver = 'cisco_apic_ml2'
@@ -4510,6 +4511,70 @@ class TestCiscoApicMechDriverHostSNAT(ApicML2IntegratedTestBase):
         subnets = self.driver.db_plugin.get_subnets(
             ctx, filters={'name': [acst.HOST_SNAT_POOL]})
         self.assertEqual(0, len(subnets))
+
+
+class TestCiscoApicMechDriverNoFabricL3(TestApicML2IntegratedPhysicalNode):
+
+    def setUp(self, service_plugins=None, ml2_opts=None):
+        # Mock out HA scheduler notifcations
+        # (irrelevant exceptions if it's not)
+        self._update_notify = mock.patch(
+            'neutron.db.l3_hascheduler_db._notify_l3_agent_ha_port_update')
+        self._update_notify.start()
+        # Configure reference L3 implementation, which
+        # disables routing and subnet configuration in the ACI fabric
+        super(TestCiscoApicMechDriverNoFabricL3, self).setUp(
+            service_plugins={'L3_ROUTER_NAT': 'router'})
+
+    def tearDown(self):
+        self._update_notify.stop()
+        super(TestCiscoApicMechDriverNoFabricL3, self).tearDown()
+
+    def test_create_subnet_no_l3(self):
+        ctx = context.get_admin_context()
+        tenant1 = self._tenant(neutron_tenant='onetenant')
+        app_prof1 = self._app_profile(neutron_tenant='onetenant')
+        self._register_agent('h1', agent_cfg=AGENT_CONF_OPFLEX)
+        net = self.create_network(
+            tenant_id='onetenant', is_admin_context=True)['network']
+        sub = self.create_subnet(
+            network_id=net['id'], cidr='192.168.0.0/24',
+            ip_version=4, is_admin_context=True)
+        router = self.create_router(api=self.ext_api,
+                                    tenant_id='onetenant')['router']
+        self.driver._add_ip_mapping_details = mock.Mock()
+        with self.port(subnet=sub, tenant_id='onetenant') as p1:
+            p1 = p1['port']
+
+        # bind to VM-host
+        self._bind_port_to_host(p1['id'], 'h1')
+        bseg_p1, bdriver = self._get_bound_seg(p1['id'])
+        self.assertEqual(bseg_p1['network_type'], 'opflex')
+        self.assertEqual('cisco_apic_ml2', bdriver)
+        self.mgr.ensure_path_created_for_port.assert_not_called()
+
+        self.l3_plugin.add_router_interface(ctx,
+                                            router['id'],
+                                            {'subnet_id': sub['subnet']['id']})
+        self.mgr.ensure_subnet_created_on_apic.assert_not_called()
+        router_port = self.driver.db_plugin.get_ports(
+            ctx, filters={'device_id': [router['id']],
+                          'network_id': [net['id']]})[0]
+        self.mgr.ensure_path_created_for_port.reset_mock()
+        self._bind_port_to_host(router_port['id'], 'lb-app-01')
+        self.mgr.ensure_path_created_for_port.assert_called()
+        bseg_p1, bdriver = self._get_bound_seg(router_port['id'])
+        self.assertEqual(1, len(self._query_dynamic_seg(net['id'])))
+        self.mgr.ensure_path_created_for_port.assert_called_once_with(
+            tenant1, net['id'], 'lb-app-01', bseg_p1['segmentation_id'],
+            app_profile_name=app_prof1, transaction=mock.ANY)
+
+        self.l3_plugin.remove_router_interface(ctx,
+                                               router['id'],
+                                               {'port_id': router_port['id']})
+        self.assertEqual(0, len(self._query_dynamic_seg(net['id'])))
+        self.mgr.ensure_path_deleted_for_port.assert_called_once_with(
+            tenant1, net['id'], 'lb-app-01', app_profile_name=app_prof1)
 
 
 class FakeNetworkContext(object):


### PR DESCRIPTION
This adds support for using the ACI fabric only
for L2. The ACI-specific L3 plugin is not used,
as L3 is handled external to the fabric (e.g. using
the reference implementation/namespace router). The
code auto-detects if an ACI-specific L3 plugin is
configured, except in the case where the Cisco Router
Service L3 Plugin with ACI integration is used. If
the Cisco Router Service L3 Plugin, and L3 is to be
handled by the fabric, then the new l3_cisco_router_plugin flag
must be set to true, in order to ensure that L2 only mode isn't
enabled/used (note: it's possible to auto-detect
this as well, but that behavior is not implemented
in this patch).

Closes noironetworks/support#350

Signed-off-by: Thomas Bachman <tbachman@yahoo.com>