### PR TITLE
Fix dependency error

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,6 +9,7 @@ hacking<0.11,>=0.10.0
 cliff>=1.14.0 # Apache-2.0
 coverage>=3.6
 fixtures>=1.3.1
+kombu==3.0.37
 mock>=1.2
 python-subunit>=0.0.18
 requests-mock>=0.6.0 # Apache-2.0


### PR DESCRIPTION
The 4.0.0 version of kombu (transitive dependency from oslo_messaging)
has a dependency issue, causing tox runs to fail. This patch fixes the
version of kombu to the last known working version.

Signed-off-by: Thomas Bachman <tbachman@yahoo.com>