### PR TITLE
Updating nameAlias field also.

### DIFF
--- a/apic_ml2/neutron/services/l3_router/apic_driver.py
+++ b/apic_ml2/neutron/services/l3_router/apic_driver.py
@@ -188,6 +188,9 @@ class ApicL3Driver(apic_driver_api.ApicL3DriverBase):
             else:
                 self.manager.disable_router(arouter_id, owner=tenant_id,
                                             transaction=trs)
+        self.manager.update_name_alias(self.manager.apic.vzBrCP, tenant_id,
+                                       'contract-%s' % router['id'],
+                                       nameAlias=router['name'])
 
     def create_floatingip_postcommit(self, context, floatingip):
         port_id = floatingip.get('port_id')

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -14,6 +14,7 @@
 #    under the License.
 
 import base64
+import copy
 import hashlib
 import hmac
 import re
@@ -2384,6 +2385,39 @@ tt':
             self._tenant(), mocked.APIC_NETWORK, transaction='transaction',
             app_profile_name=self._app_profile(),
             bd_name=self._scoped_name(mocked.APIC_NETWORK))
+        expected_calls = [
+            mock.call(mgr.apic.fvBD, self._tenant(),
+                      self._scoped_name(mocked.APIC_NETWORK),
+                      nameAlias=mocked.APIC_NETWORK + '-name'),
+            mock.call(mgr.apic.fvAEPg, self._tenant(),
+                      self._app_profile(),
+                      mocked.APIC_NETWORK,
+                      nameAlias=mocked.APIC_NETWORK + '-name')]
+        self._check_call_list(expected_calls,
+                              mgr.update_name_alias.call_args_list)
+
+    def test_update_network_postcommit(self):
+        ctx = self._get_network_context(mocked.APIC_TENANT,
+                                        mocked.APIC_NETWORK,
+                                        TEST_SEGMENT1)
+        ctx.original = copy.copy(ctx.current)
+        mgr = self.driver.apic_manager
+        self.driver.update_network_postcommit(ctx)
+        self.assertFalse(mgr.apic.fvBD.update.called)
+        self.assertFalse(mgr.apic.fvAEPg.update.called)
+
+        # try again with a new network name
+        ctx.original['name'] = 'old_network_name'
+        self.driver.update_network_postcommit(ctx)
+        expected_calls = [
+            mock.call(mgr.apic.fvBD, self._tenant(),
+                      self._scoped_name(mocked.APIC_NETWORK),
+                      nameAlias=mocked.APIC_NETWORK + '-name'),
+            mock.call(mgr.apic.fvAEPg, self._tenant(),
+                      self._app_profile(), mocked.APIC_NETWORK,
+                      nameAlias=mocked.APIC_NETWORK + '-name')]
+        self._check_call_list(expected_calls,
+                              mgr.update_name_alias.call_args_list)
 
     def test_create_external_network_postcommit(self):
         net_ctx = self._get_network_context(mocked.APIC_TENANT,

--- a/apic_ml2/neutron/tests/unit/services/l3_router/test_l3_apic_plugin.py
+++ b/apic_ml2/neutron/tests/unit/services/l3_router/test_l3_apic_plugin.py
@@ -90,7 +90,7 @@ class TestCiscoApicL3Plugin(testlib_api.SqlTestCase,
         self.contract = FakeContract()
         self.plugin.get_router = mock.Mock(
             return_value={'id': ROUTER, 'admin_state_up': True,
-                          'tenant_id': TENANT})
+                          'tenant_id': TENANT, 'name': ROUTER + '-name'})
         apic_driver.manager.apic.transaction = self.fake_transaction
 
         self.plugin._apic_driver._aci_mech_driver = self.ml2_driver


### PR DESCRIPTION
This patch will cover BD, EPG and contract. Don't need to cover
l3out and external EPG as they are all preexisting in customer
env. Tenant and AP will be covered in a separate patch as currently
we don't get tenant name change notification in our MD...