### PR TITLE
Use config parameters for keystone notification exchange and topic

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -488,6 +488,10 @@ class APICMechanismDriver(api.MechanismDriver,
         self._setup_rpc()
         self._setup_topology_rpc_listeners()
         self._setup_opflex_rpc_listeners()
+        self.keystone_notification_exchange = (self.apic_manager.
+                                               keystone_notification_exchange)
+        self.keystone_notification_topic = (self.apic_manager.
+                                            keystone_notification_topic)
         self._setup_keystone_notification_listeners()
         self.name_mapper = NameMapper(self.apic_manager.apic_mapper)
         self.synchronizer = None
@@ -531,8 +535,9 @@ class APICMechanismDriver(api.MechanismDriver,
 
     def _setup_keystone_notification_listeners(self):
         transport = oslo_messaging.get_transport(cfg.CONF)
-        targets = [oslo_messaging.Target(exchange='keystone',
-                                         topic='notifications', fanout=True)]
+        targets = [oslo_messaging.Target(
+            exchange=self.keystone_notification_exchange,
+            topic=self.keystone_notification_topic, fanout=True)]
         endpoints = [KeystoneNotificationEndpoint(self)]
         pool = "listener-workers"
         server = oslo_messaging.get_notification_listener(


### PR DESCRIPTION
If user changes these in keystone.conf then they have to change
these 2 parameters also.