### PR TITLE
Set project when doing neutron DB migrations

### DIFF
--- a/apic_ml2/neutron/db/migration/cli.py
+++ b/apic_ml2/neutron/db/migration/cli.py
@@ -20,5 +20,5 @@ def main():
         'script_location',
         'apic_ml2.neutron.db.migration:alembic_migrations')
     config.neutron_config = CONF
-    CONF()
+    CONF(project='neutron')
     CONF.command.func(config, CONF.command.name)


### PR DESCRIPTION
That way, the default configuration files/dirs from the neutron
projects are read when doing the DB migrations.
This is useful if eg. some configuration files are in
/etc/neutron/neutron.conf.d/ . Theses files will then be automatically
evaluated.