### PR TITLE
L3 plugin member not referenced correctly

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -282,7 +282,7 @@ class APICMechanismDriver(api.MechanismDriver,
     @property
     def fabric_l3(self):
         if self._fabric_l3 is None:
-            self._fabric_l3 = self._cisco_l3 or hasattr(self._l3_plugin,
+            self._fabric_l3 = self._cisco_l3 or hasattr(self.l3_plugin,
                                                         '_apic_driver')
         return self._fabric_l3
 


### PR DESCRIPTION
This patch fixes a bug where the L3 plugin isn't referenced
correctly. Instead of using the property to get the member,
the code was referencing the private member backing the property.
This led to situations where the private member wasn't getting
initialized but was referenced, leading to incorrect behavior.

Closes-issue: 437