### PR TITLE
Allow floating IPs to be allocated with ML2 DNS extension

### DIFF
--- a/apic_ml2/neutron/services/l3_router/l3_apic.py
+++ b/apic_ml2/neutron/services/l3_router/l3_apic.py
@@ -54,6 +54,9 @@ class ApicL3ServicePlugin(common_db_mixin.CommonDbMixin,
     supported_extension_aliases = ["router", "ext-gw-mode", "extraroute",
                                    "l3-flavors"]
 
+    # Set this to False so that the mixin code doesn't try to call
+    # _process_dns_floatingip_create_precommit
+    _dns_integration = False
     def __init__(self):
         super(ApicL3ServicePlugin, self).__init__()
         self.synchronizer = None


### PR DESCRIPTION
When the DNS extension for ML2 is enabled, floating IP allocation fails due to  _process_dns_floatingip_create_precommit not being implemented in ApicL3ServicePlugin.

 This sets a flag so that the Mixin code will not try to call that method.