### PR TITLE
Use Routing Context Feature

### DIFF
--- a/apic_ml2/neutron/db/migration/alembic_migrations/versions/7a07faecf529_cisco_apic_extension.py
+++ b/apic_ml2/neutron/db/migration/alembic_migrations/versions/7a07faecf529_cisco_apic_extension.py
@@ -36,6 +36,18 @@ def upgrade():
                                 ondelete='CASCADE'),
         sa.PrimaryKeyConstraint('network_id')
     )
+    op.create_table(
+        'apic_ml2_router_extensions',
+        sa.Column('router_id', sa.String(36), nullable=False),
+        sa.Column('use_routing_context', sa.String(36)),
+        sa.ForeignKeyConstraint(['router_id'], ['routers.id'],
+                                name='apic_ml2_router_extn_fk_router_id',
+                                ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['use_routing_context'], ['routers.id'],
+                                name='apic_ml2_router_extn_fk_routing_cxt',
+                                ondelete='RESTRICT'),
+        sa.PrimaryKeyConstraint('router_id')
+    )
 
 
 def downgrade():

--- a/apic_ml2/neutron/extensions/cisco_apic_l3.py
+++ b/apic_ml2/neutron/extensions/cisco_apic_l3.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2017 Cisco Systems Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from neutron.api import extensions
+from neutron.extensions import l3
+
+ALIAS = 'cisco-apic-l3'
+USE_ROUTING_CONTEXT = 'apic:use_routing_context'
+
+
+EXT_GW_ATTRIBUTES = {
+    USE_ROUTING_CONTEXT: {
+        'allow_post': True, 'allow_put': False,
+        'is_visible': True, 'default': None,
+        'validate': {'type:uuid_or_none': None},
+    }
+}
+
+EXTENDED_ATTRIBUTES_2_0 = {
+    l3.ROUTERS: dict(EXT_GW_ATTRIBUTES.items())
+}
+
+
+class Cisco_apic_l3(extensions.ExtensionDescriptor):
+
+    @classmethod
+    def get_name(cls):
+        return "Cisco APIC L3"
+
+    @classmethod
+    def get_alias(cls):
+        return ALIAS
+
+    @classmethod
+    def get_description(cls):
+        return ("Extension exposing mapping of Neutron L3 resources to Cisco "
+                "APIC constructs")
+
+    @classmethod
+    def get_updated(cls):
+        return "2017-06-06T12:00:00-00:00"
+
+    def get_extended_resources(self, version):
+        if version == "2.0":
+            return EXTENDED_ATTRIBUTES_2_0
+        else:
+            return {}

--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/extension_db.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/extension_db.py
@@ -17,6 +17,7 @@ from neutron_lib.db import model_base
 import sqlalchemy as sa
 
 from apic_ml2.neutron.extensions import cisco_apic
+from apic_ml2.neutron.extensions import cisco_apic_l3
 
 
 class NetworkExtensionDb(model_base.BASEV2):
@@ -27,6 +28,17 @@ class NetworkExtensionDb(model_base.BASEV2):
         sa.String(36), sa.ForeignKey('networks.id', ondelete="CASCADE"),
         primary_key=True)
     allow_route_leak = sa.Column(sa.Boolean)
+
+
+class RouterExtensionDb(model_base.BASEV2):
+
+    __tablename__ = 'apic_ml2_router_extensions'
+
+    router_id = sa.Column(
+        sa.String(36), sa.ForeignKey('routers.id', ondelete="CASCADE"),
+        primary_key=True)
+    use_routing_context = sa.Column(
+        sa.String(36), sa.ForeignKey('routers.id', ondelete="RESTRICT"))
 
 
 class ExtensionDbMixin(object):
@@ -51,3 +63,19 @@ class ExtensionDbMixin(object):
         if cisco_apic.ALLOW_ROUTE_LEAK in res_dict:
             db_obj['allow_route_leak'] = res_dict[cisco_apic.ALLOW_ROUTE_LEAK]
         session.add(db_obj)
+
+    def get_router_extn_db(self, session, router_id):
+        db_obj = (session.query(RouterExtensionDb).filter_by(
+                  router_id=router_id).first())
+        result = {}
+        if db_obj:
+            self._set_if_not_none(result, cisco_apic_l3.USE_ROUTING_CONTEXT,
+                                  db_obj['use_routing_context'])
+        return result
+
+    def set_router_extn_db(self, session, router_id, res_dict):
+        if res_dict.get(cisco_apic_l3.USE_ROUTING_CONTEXT):
+            db_obj = RouterExtensionDb(router_id=router_id)
+            db_obj['use_routing_context'] = res_dict[
+                cisco_apic_l3.USE_ROUTING_CONTEXT]
+            session.add(db_obj)

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -103,6 +103,7 @@ AGENT_CONF_OPFLEX = {'alive': True, 'binary': 'somebinary',
 APIC_EXTERNAL_RID = '1.0.0.1'
 TEST_TENANT = test_plugin.TEST_TENANT_ID
 ALLOW_ROUTE_LEAK = 'apic:allow_route_leak'
+USE_ROUTING_CONTEXT = 'apic:use_routing_context'
 
 
 def echo(context, id, prefix=''):
@@ -498,14 +499,20 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
             ip_version=4, is_admin_context=True)
         router = self.create_router(api=self.ext_api,
                                     tenant_id=mocked.APIC_TENANT)['router']
+        # use_routing_context router
+        router1 = self.create_router(api=self.ext_api,
+                                     tenant_id=mocked.APIC_TENANT,
+                                     **{'apic:use_routing_context':
+                                        router['id']}
+                                     )['router']
         self.l3_plugin.add_router_interface(
-            context.get_admin_context(), router['id'],
+            context.get_admin_context(), router1['id'],
             {'subnet_id': sub['subnet']['id']})
         self.l3_plugin.add_router_interface(
             context.get_admin_context(), router['id'],
             {'subnet_id': sub3['subnet']['id']})
         self.l3_plugin.add_router_interface(
-            context.get_admin_context(), router['id'],
+            context.get_admin_context(), router1['id'],
             {'subnet_id': sub_route_leak['subnet']['id']})
         self.l3_plugin.add_router_interface(
             context.get_admin_context(), router['id'],
@@ -1052,6 +1059,18 @@ class ApicML2IntegratedTestCase(ApicML2IntegratedTestBase):
         self.l3_plugin.add_router_interface(
             context.get_admin_context(), rtr2['id'],
             {'port_id': p2['id']})
+        # use_routing_context router
+        rtr3 = self.create_router(
+            api=self.ext_api, tenant_id=mocked.APIC_TENANT,
+            **{'apic:use_routing_context': rtr1['id']})['router']
+        p3 = self.create_port(
+            network_id=net_route_leak['id'], tenant_id=mocked.APIC_TENANT,
+            device_owner='network:router_interface',
+            fixed_ips=[{'subnet_id': sub_route_leak['id'],
+                        'ip_address': '10.0.0.3'}])['port']
+        self.l3_plugin.add_router_interface(
+            context.get_admin_context(), rtr3['id'],
+            {'port_id': p3['id']})
 
         details = self._get_gbp_details(p1['id'], 'h1')
 
@@ -1894,13 +1913,23 @@ l3extRsPathL3OutAtt": {"attributes": {"ifInstT": "sub-interface", "encap": \
                                           'net_id',
                                           'vm1', net_ctx, HOST_ID1,
                                           interface=True)
-        self.driver._l3_plugin.get_router = mock.Mock(
-            return_value={'id': mocked.APIC_ROUTER,
-                          'name': mocked.APIC_ROUTER + '-name',
-                          'tenant_id': net_tenant,
-                          'external_gateway_info':
-                              {'network_id': ext_net,
-                               'external_fixed_ips': []}})
+        if route_leak:
+            self.driver._l3_plugin.get_router = mock.Mock(
+                return_value={'id': 'some_id',
+                              'name': mocked.APIC_ROUTER + '-name',
+                              'tenant_id': net_tenant,
+                              'apic:use_routing_context': mocked.APIC_ROUTER,
+                              'external_gateway_info':
+                                  {'network_id': ext_net,
+                                   'external_fixed_ips': []}})
+        else:
+            self.driver._l3_plugin.get_router = mock.Mock(
+                return_value={'id': mocked.APIC_ROUTER,
+                              'name': mocked.APIC_ROUTER + '-name',
+                              'tenant_id': net_tenant,
+                              'external_gateway_info':
+                                  {'network_id': ext_net,
+                                   'external_fixed_ips': []}})
         port_ctx._plugin.get_network = mock.Mock(
             return_value={'name': ext_net + '-name',
                           'tenant_id': mocked.APIC_TENANT,
@@ -2472,13 +2501,23 @@ tt':
                                           'net_id',
                                           'vm1', net_ctx, HOST_ID1,
                                           interface=True)
-        self.driver._l3_plugin.get_router = mock.Mock(
-            return_value={'id': mocked.APIC_ROUTER,
-                          'name': mocked.APIC_ROUTER + '-name',
-                          'tenant_id': mocked.APIC_TENANT,
-                          'external_gateway_info':
-                              {'network_id': mocked.APIC_NETWORK_EDGE_NAT,
-                               'external_fixed_ips': []}})
+        if route_leak:
+            self.driver._l3_plugin.get_router = mock.Mock(
+                return_value={'id': 'some_id',
+                              'name': mocked.APIC_ROUTER + '-name',
+                              'tenant_id': mocked.APIC_TENANT,
+                              'apic:use_routing_context': mocked.APIC_ROUTER,
+                              'external_gateway_info':
+                                  {'network_id': mocked.APIC_NETWORK_EDGE_NAT,
+                                   'external_fixed_ips': []}})
+        else:
+            self.driver._l3_plugin.get_router = mock.Mock(
+                return_value={'id': mocked.APIC_ROUTER,
+                              'name': mocked.APIC_ROUTER + '-name',
+                              'tenant_id': mocked.APIC_TENANT,
+                              'external_gateway_info':
+                                  {'network_id': mocked.APIC_NETWORK_EDGE_NAT,
+                                   'external_fixed_ips': []}})
         port_ctx._plugin.get_network = mock.Mock(
             return_value={'name': mocked.APIC_NETWORK_EDGE_NAT + '-name',
                           'router:external': True})
@@ -4444,7 +4483,9 @@ class VrfPerRouterBase(object):
 
     def test_create_delete_router_vrf(self):
         routers = [{'id': 'r1', 'tenant_id': 'coke_1_tenant'},
-                   {'id': 'r2', 'tenant_id': 'another_coke_1_tenant'}]
+                   {'id': 'r2', 'tenant_id': 'another_coke_1_tenant'},
+                   {'id': 'r3', 'tenant_id': 'coke_1_tenant',
+                    'apic:use_routing_context': 'r1'}]
 
         for rtr in routers:
             is_vrf_per_router = (rtr['tenant_id'] == 'coke_1_tenant')
@@ -4455,7 +4496,7 @@ class VrfPerRouterBase(object):
 
             mgr.ensure_context_enforced.reset_mock()
             self.driver.create_vrf_per_router(rtr, 'txn')
-            if is_vrf_per_router:
+            if is_vrf_per_router and not rtr.get(USE_ROUTING_CONTEXT):
                 mgr.ensure_context_enforced.assert_called_once_with(
                     owner=vrf_tenant, ctx_id=vrf_name, transaction='txn')
             else:
@@ -4463,7 +4504,7 @@ class VrfPerRouterBase(object):
 
             mgr.ensure_context_deleted.reset_mock()
             self.driver.delete_vrf_per_router(rtr, 'txn')
-            if is_vrf_per_router:
+            if is_vrf_per_router and not rtr.get(USE_ROUTING_CONTEXT):
                 mgr.ensure_context_deleted.assert_called_once_with(
                     owner=vrf_tenant, ctx_id=vrf_name, transaction='txn')
             else:
@@ -4497,6 +4538,36 @@ class VrfPerRouterBase(object):
                                   self.driver.create_port_precommit, port)
                 self.assertRaises(md.OnlyOneRouterPermittedIfVrfPerRouter,
                                   self.driver.update_port_precommit, port)
+
+    def test_use_routing_context_routers_precommit(self):
+        intf_ports = []
+
+        def get_ports(ctx, filters):
+            return [p.current for p in intf_ports]
+
+        self.driver._l3_plugin.get_routers = mock.Mock(return_value=[
+            {'id': mocked.APIC_ROUTER + '-0', 'tenant_id': mocked.APIC_TENANT},
+            {'id': mocked.APIC_ROUTER + '-1', 'tenant_id': mocked.APIC_TENANT,
+             'apic:use_routing_context': mocked.APIC_ROUTER + '-0'}])
+        net_ctx = self._get_network_context(mocked.APIC_TENANT,
+                                            mocked.APIC_NETWORK, TEST_SEGMENT1)
+        for x in range(0, 3):
+            rtr = '%s-%d' % (mocked.APIC_ROUTER, x / 2)
+            self.driver._l3_plugin.get_router = mock.Mock(return_value={
+                'id': rtr, 'tenant_id': mocked.APIC_TENANT,
+                'apic:use_routing_context': mocked.APIC_ROUTER + '-0'})
+            port = self._get_port_context(mocked.APIC_TENANT,
+                                          mocked.APIC_NETWORK,
+                                          'intf', net_ctx, HOST_ID1,
+                                          router_owner=rtr,
+                                          interface=True)
+            port.current['id'] += x
+            port._plugin.get_ports = get_ports
+            intf_ports.append(port)
+
+            # no exception expected
+            self.driver.create_port_precommit(port)
+            self.driver.update_port_precommit(port)
 
     def test_multiple_intf_ports_delete(self):
         intf_ports = []
@@ -5204,6 +5275,46 @@ class TestExtensionAttributes(ApicML2IntegratedTestBase):
         session = db_api.get_session()
         extn = extn_db.ExtensionDbMixin()
         self.assertFalse(extn.get_network_extn_db(session, net['id']))
+
+    def test_router_lifecycle(self):
+        session = db_api.get_session()
+        extn = extn_db.ExtensionDbMixin()
+        # default value
+        rtr0 = self.create_router(api=self.ext_api,
+                                  expected_res_status=201)['router']
+        self.assertEqual(None, rtr0[USE_ROUTING_CONTEXT])
+        self.assertFalse(extn.get_router_extn_db(session, rtr0['id']))
+        # bad value
+        self.create_router(api=self.ext_api,
+                           expected_res_status=400,
+                           **{'apic:use_routing_context': '12345'})
+        self.create_router(api=self.ext_api,
+                           expected_res_status=500,
+                           **{'apic:use_routing_context':
+                              '39266936-70b8-437b-b779-74ae099ff0db'})
+        # good value
+        rtr1 = self.create_router(api=self.ext_api,
+                                  expected_res_status=201,
+                                  **{'apic:use_routing_context': rtr0['id']}
+                                  )['router']
+        self.assertEqual(rtr0['id'], rtr1[USE_ROUTING_CONTEXT])
+        self.assertEqual(extn.get_router_extn_db(session, rtr1['id']),
+                         {'apic:use_routing_context': rtr0['id']})
+        # can't delete rtr0 now
+        self.delete_router(rtr0['id'], api=self.ext_api,
+                           expected_res_status=500)
+        # update is not allowed
+        self.update_router(
+            rtr1['id'], api=self.ext_api,
+            expected_res_status=400,
+            **{'apic:use_routing_context': rtr1['id']})
+        # deletion
+        self.delete_router(rtr1['id'], api=self.ext_api,
+                           expected_res_status=204)
+        # can delete rtr0 now after rtr1 is gone
+        self.delete_router(rtr0['id'], api=self.ext_api,
+                           expected_res_status=204)
+        self.assertFalse(extn.get_router_extn_db(session, rtr1['id']))
 
 
 class FakeNetworkContext(object):


### PR DESCRIPTION
1. defined 'apic:use_routing_context' which specifies the ID of an
existing router as the router extension attribute. This means this
new router will be using the same vrf of that existing router under
per router vrf mode.
2. Allow a network to be connected to those same vrf routers under
per router vrf mode.
3. All the networks connected to those same vrf routers will be
considered the internal_subnets under the same vrf in the rdconfig
file.
4. When a route_leak_network is connected to a use_routing_context
router which points to r1 for example, the created leak EPG/BD name
will be based on r1 instead.