### PR TITLE
Fix DVS agent library

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -67,7 +67,7 @@ from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import nova_client
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import patch  # noqa
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import rpc as t_rpc
 
-DVS_AGENT_KLASS = 'vmware_dvs.api.dvs_agent_rpc_api.DVSClientAPI'
+DVS_AGENT_KLASS = 'networking_vsphere.common.dvs_agent_rpc_api.DVSClientAPI'
 LOG = logging.getLogger(__name__)
 n_db.AUTO_DELETE_PORT_OWNERS.append(acst.DEVICE_OWNER_SNAT_PORT)
 _apic_driver_instance = None
@@ -400,16 +400,16 @@ class APICMechanismDriver(api.MechanismDriver,
             currentcopy = copy.copy(context.current)
             currentcopy['portgroup_name'] = (
                 vif_details['dvs_port_group_name'])
-            booked_port_key = None
+            booked_port_info = None
             if self.dvs_notifier:
-                booked_port_key = self.dvs_notifier.bind_port_call(
+                booked_port_info = self.dvs_notifier.bind_port_call(
                     currentcopy,
                     context.network.network_segments,
                     context.network.current,
                     context.host
                 )
-            if booked_port_key:
-                vif_details['dvs_port_key'] = booked_port_key
+            if booked_port_info:
+                vif_details['dvs_port_key'] = booked_port_info['key']
 
             context.set_binding(segment[api.ID],
                                 acst.VIF_TYPE_DVS, vif_details)

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_mechanism_driver.py
@@ -3857,7 +3857,7 @@ class ApicML2IntegratedTestCaseDvs(ApicML2IntegratedTestBase):
         self.driver.agent_type = ofcst.AGENT_TYPE_OPFLEX_OVS
         self.driver._dvs_notifier = mock.MagicMock()
         self.driver.dvs_notifier.bind_port_call = mock.Mock(
-            return_value=BOOKED_PORT_VALUE)
+            return_value={'key': BOOKED_PORT_VALUE})
 
     def _verify_dvs_notifier(self, notifier, port, host):
             # can't use getattr() with mock, so use eval instead

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -22,6 +22,7 @@ testtools>=1.4.0 # MIT
 testscenarios>=0.4 # Apache-2.0/BSD
 WebTest>=2.0 # MIT
 oslotest>=1.10.0 # Apache-2.0
+oslo.messaging<5.31.0
 os-testr>=0.1.0
 tempest-lib>=0.14.0  # Apache-2.0
 ddt>=0.7.0


### PR DESCRIPTION
The directory structure for the DVS agent changed, which
caused the DVS agent notifier class load to fail. This patch
usees the new directory path.