### PR TITLE
Allow different pod_id in LLDP

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/apic_topology.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/apic_topology.py
@@ -40,13 +40,13 @@ from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import (mechanism_apic as
                                                              ma)
 from apic_ml2.neutron.plugins.ml2.drivers.cisco.apic import rpc as arpc
 
-ACI_CHASSIS_DESCR_FORMAT = 'topology/pod-1/node-(\d+)'
+ACI_CHASSIS_DESCR_FORMAT = 'topology/pod-(\d+)/node-(\d+)'
 ACI_PORT_DESCR_FORMATS = [
-    'topology/pod-1/node-(\d+)/sys/conng/path-\[eth(\d+)/(\d+(\/\d+)*)\]',
-    'topology/pod-1/paths-(\d+)/pathep-\[eth(\d+)/(\d+(\/\d+)*)\]',
+    'topology/pod-(\d+)/node-(\d+)/sys/conng/path-\[eth(\d+)/(\d+(\/\d+)*)\]',
+    'topology/pod-(\d+)/paths-(\d+)/pathep-\[eth(\d+)/(\d+(\/\d+)*)\]',
 ]
 ACI_PORT_LOCAL_FORMAT = 'Eth(\d+)/(\d+(\/\d+)*)'
-ACI_VPCPORT_DESCR_FORMAT = ('topology/pod-1/protpaths-(\d+)-(\d+)/pathep-'
+ACI_VPCPORT_DESCR_FORMAT = ('topology/pod-(\d+)/protpaths-(\d+)-(\d+)/pathep-'
                             '\[(.*)\]')
 
 AGENT_FORCE_UPDATE_COUNT = 5
@@ -193,7 +193,7 @@ class ApicTopologyAgent(manager.Manager):
                         curr_peers[interface] != peer):
                     LOG.debug('reporting peer removal: %s', peer)
                     self.service_agent.update_link(
-                        context, peer[0], peer[1], None, 0, 0, 0, '')
+                        context, peer[0], peer[1], None, 0, 0, 0, 0, '')
                 if (interface not in curr_peers or
                         curr_peers[interface] != peer or
                         force_send):
@@ -206,7 +206,7 @@ class ApicTopologyAgent(manager.Manager):
             for peer in curr_peers.values():
                 LOG.debug('reporting peer removal: %s', peer)
                 self.service_agent.update_link(
-                    context, peer[0], peer[1], None, 0, 0, 0, '')
+                    context, peer[0], peer[1], None, 0, 0, 0, 0, '')
 
         except Exception:
             LOG.exception(_LE("APIC service agent: exception in LLDP parsing"))
@@ -233,23 +233,23 @@ class ApicTopologyAgent(manager.Manager):
                     match = regexp.match(value)
                     if match:
                         mac = self._get_mac(interface)
-                        switch, module, port = match.group(1, 2, 3)
+                        pod_id, switch, module, port = match.group(1, 2, 3, 4)
                         peer = (self.host, interface, mac,
-                                switch, module, port, port_desc)
+                                switch, module, port, pod_id, port_desc)
                         if interface not in peers:
                             peers[interface] = []
                         peers[interface].append(peer)
                 match = self.vpcport_desc_re.match(value)
                 if match:
                     mac = self._get_mac(interface)
-                    switch1, switch2, bundle = match.group(1, 2, 3)
+                    pod_id, switch1, switch2, bundle = match.group(1, 2, 3, 4)
                     switch, module, port = None, None, None
                     if (bundle is not None and
                             'chassis.descr' in interfaces[interface]):
                         value = interfaces[interface]['chassis.descr']
                         match = self.chassis_desc_re.match(value)
                         if match:
-                            switch = match.group(1)
+                            switch = match.group(2)
                         if (switch is not None and
                                 'port.local' in interfaces[interface]):
                             value = interfaces[interface]['port.local']
@@ -259,7 +259,8 @@ class ApicTopologyAgent(manager.Manager):
                             if module is not None and port is not None:
                                 vpcmodule = VPCMODULE_NAME % (module, port)
                                 peer = (self.host, interface, mac,
-                                        switch, vpcmodule, bundle, port_desc)
+                                        switch, vpcmodule, bundle,
+                                        pod_id, port_desc)
                                 if interface not in peers:
                                     peers[interface] = []
                                 peers[interface].append(peer)

--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/rpc.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/rpc.py
@@ -43,7 +43,7 @@ class ApicTopologyRpcCallback(object):
                             external=True)
     def update_link(self, context,
                     host, interface, mac,
-                    switch, module, port, port_description=''):
+                    switch, module, port, pod_id='1', port_description=''):
         LOG.debug("APIC service agent: received update_link: %s",
                   ", ".join(map(str,
                                 [host, interface, mac, switch, module, port])))
@@ -188,11 +188,11 @@ class ApicTopologyServiceNotifierApi(object):
         self.client = rpc.get_client(target)
 
     def update_link(self, context, host, interface, mac, switch, module, port,
-                    port_description=''):
+                    pod_id='1', port_description=''):
         cctxt = self.client.prepare(version='1.2', fanout=True)
         cctxt.cast(context, 'update_link', host=host, interface=interface,
                    mac=mac, switch=switch, module=module, port=port,
-                   port_description=port_description)
+                   pod_id=pod_id, port_description=port_description)
 
     def delete_link(self, context, host, interface):
         cctxt = self.client.prepare(version='1.2', fanout=True)

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_common.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_common.py
@@ -95,9 +95,9 @@ SERVICE_HOST_IFACE = 'eth0'
 SERVICE_HOST_MAC = 'aa:ee:ii:oo:uu:yy'
 
 SERVICE_PEER_CHASSIS_NAME = 'leaf4'
-SERVICE_PEER_CHASSIS = 'topology/pod-1/node-' + APIC_EXT_SWITCH
+SERVICE_PEER_CHASSIS = 'topology/pod-2/node-' + APIC_EXT_SWITCH
 SERVICE_PEER_PORT_LOCAL = 'Eth%s/%s' % (APIC_EXT_MODULE, APIC_EXT_PORT)
-SERVICE_PEER_PORT_DESC = ('topology/pod-1/paths-%s/pathep-[%s]' %
+SERVICE_PEER_PORT_DESC = ('topology/pod-2/paths-%s/pathep-[%s]' %
                           (APIC_EXT_SWITCH, SERVICE_PEER_PORT_LOCAL.lower()))
 
 HOST_POOL_CIDR = "192.168.0.1/24"

--- a/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_topology_agent.py
+++ b/apic_ml2/neutron/tests/unit/ml2/drivers/cisco/apic/test_cisco_apic_topology_agent.py
@@ -184,7 +184,7 @@ class TestCiscoApicTopologyAgent(base.BaseTestCase,
             expected = [(mocked.SERVICE_HOST, mocked.SERVICE_HOST_IFACE,
                          mocked.SERVICE_HOST_MAC, mocked.APIC_EXT_SWITCH,
                          mocked.APIC_EXT_MODULE, mocked.APIC_EXT_PORT,
-                         mocked.SERVICE_PEER_PORT_DESC)]
+                         '2', mocked.SERVICE_PEER_PORT_DESC)]
             self.assertEqual(expected,
                              peers[mocked.SERVICE_HOST_IFACE])
 
@@ -192,7 +192,7 @@ class TestCiscoApicTopologyAgent(base.BaseTestCase,
             self.agent.peers = {}
             expected = (mocked.SERVICE_HOST, mocked.SERVICE_HOST_IFACE,
                         mocked.SERVICE_HOST_MAC, mocked.APIC_EXT_SWITCH,
-                        mocked.APIC_EXT_MODULE, mocked.APIC_EXT_PORT,
+                        mocked.APIC_EXT_MODULE, mocked.APIC_EXT_PORT, '2',
                         mocked.SERVICE_PEER_PORT_DESC)
             peers = {mocked.SERVICE_HOST_IFACE: [expected]}
             context = mock.Mock()
@@ -207,7 +207,7 @@ class TestCiscoApicTopologyAgent(base.BaseTestCase,
         def test_check_for_new_peers_with_peers(self):
             expected = (mocked.SERVICE_HOST, mocked.SERVICE_HOST_IFACE,
                         mocked.SERVICE_HOST_MAC, mocked.APIC_EXT_SWITCH,
-                        mocked.APIC_EXT_MODULE, mocked.APIC_EXT_PORT,
+                        mocked.APIC_EXT_MODULE, mocked.APIC_EXT_PORT, '2',
                         mocked.SERVICE_PEER_PORT_DESC)
             peers = {mocked.SERVICE_HOST_IFACE: [expected]}
             self.agent.peers = {mocked.SERVICE_HOST_IFACE:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
--e git+https://github.com/openstack/neutron.git@stable/newton#egg=neutron
+-e git+https://github.com/openstack/neutron.git@newton-eol#egg=neutron
 -e git+https://github.com/Mirantis/vmware-dvs.git@master#egg=vmware_dvs
 hacking<0.11,>=0.10.0
 


### PR DESCRIPTION
This is the backport of the pull request below. Since LLDP code resides
in different repo so I can't just use the cherry-pick to do it.
https://github.com/noironetworks/python-opflex-agent/pull/74

Changes to the corresponding back-end RPC call is done in this patch:
https://review.openstack.org/#/c/517780/