### PR TITLE
Fix db-manage for RPM packaging

### DIFF
--- a/rpm/neutron-ml2-driver-apic.spec.in
+++ b/rpm/neutron-ml2-driver-apic.spec.in
@@ -51,7 +51,7 @@ install -p -D -m 0644 rpm/%{service_agent} %{buildroot}/%{_unitdir}/%{service_ag
         /bin/systemctl daemon-reload >dev/null || :
     fi
 %endif
-apic-ml2-db-manage --config-file /etc/neutron/neutron.conf upgrade head
+apic-ml2-db-manage --config-file /etc/neutron/neutron.conf upgrade head || true
 
 %preun
 %if 0%{?systemd_preun:1}


### PR DESCRIPTION
The existence of the SQL server isn't guaranteed when this package
is installed, so db-manage scripts should pipe to true in order to
prevent installer failures.