### PR TITLE
Fix NovaClient singleton pattern

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/nova_client.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/nova_client.py
@@ -32,7 +32,7 @@ def _get_client():
 class NovaClient(object):
 
     def __init__(self):
-        self.client = n_nova.Notifier().nclient
+        self.client = _get_client()
 
     def get_server(self, server_id):
         try:


### PR DESCRIPTION
The method to use the singleton pattern with NovaClient was
created, but never used. This patch uses the pattern.