### PR TITLE
Remove connected subnets qualifier

### DIFF
--- a/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
+++ b/apic_ml2/neutron/plugins/ml2/drivers/cisco/apic/mechanism_apic.py
@@ -1077,8 +1077,7 @@ class APICMechanismDriver(api.MechanismDriver,
                 # use the first DHCP agent in our list for the
                 # metadata host-route next-hop IPs
                 if not metadata and dhcp_ports and (
-                    not self.enable_metadata_opt or
-                    (self.enable_metadata_opt and not default)):
+                        not self.enable_metadata_opt):
                     for ip in dhcp_ports[dhcp_ports.keys()[0]]:
                         subnet['host_routes'].append(
                             {'destination': dhcp.METADATA_DEFAULT_CIDR,


### PR DESCRIPTION
Commit 7e97a831b27f74e78609ddd014bdd6853168e4e8 included a backport
from group-based-policy that checks to see if a subnet is connected
to neutron router. This check isn't needed for the apic-ml2-driver,
since subnets are always configured under bridge domains in APIC.