### PR TITLE
Remove un-needed transaction scoping

### DIFF
--- a/apic_ml2/neutron/db/port_ha_ipaddress_binding.py
+++ b/apic_ml2/neutron/db/port_ha_ipaddress_binding.py
@@ -47,33 +47,25 @@ class HAIPAddressToPortAssocation(model_base.BASEV2):
 class PortForHAIPAddress(object):
 
     def _get_ha_ipaddress(self, port_id, ipaddress, session=None):
-        ip = None
         session = session or db_api.get_session()
-        with session.begin(subtransactions=True):
-            ip = session.query(HAIPAddressToPortAssocation).filter_by(
-                port_id=port_id, ha_ip_address=ipaddress).first()
-        return ip
+        return session.query(HAIPAddressToPortAssocation).filter_by(
+            port_id=port_id, ha_ip_address=ipaddress).first()
 
     def get_port_for_ha_ipaddress(self, ipaddress, network_id,
                                   session=None):
         """Returns the Neutron Port ID for the HA IP Addresss."""
-        port_ha_ip = None
         session = session or db_api.get_session()
-        with session.begin(subtransactions=True):
-            port_ha_ip = session.query(HAIPAddressToPortAssocation).join(
-                models_v2.Port).filter(
-                    HAIPAddressToPortAssocation.ha_ip_address ==
-                    ipaddress).filter(
-                        models_v2.Port.network_id == network_id).first()
+        port_ha_ip = session.query(HAIPAddressToPortAssocation).join(
+            models_v2.Port).filter(
+                HAIPAddressToPortAssocation.ha_ip_address == ipaddress).filter(
+                    models_v2.Port.network_id == network_id).first()
         return port_ha_ip
 
     def get_ha_ipaddresses_for_port(self, port_id):
         """Returns the HA IP Addressses associated with a Port."""
-        objs = []
         session = db_api.get_session()
-        with session.begin(subtransactions=True):
-            objs = session.query(HAIPAddressToPortAssocation).filter_by(
-                port_id=port_id).all()
+        objs = session.query(HAIPAddressToPortAssocation).filter_by(
+            port_id=port_id).all()
         return sorted([x['ha_ip_address'] for x in objs])
 
     def set_port_id_for_ha_ipaddress(self, port_id, ipaddress, session=None):
@@ -107,11 +99,8 @@ class PortForHAIPAddress(object):
                 return
 
     def get_ha_port_associations(self):
-        associations = []
         session = db_api.get_session()
-        with session.begin(subtransactions=True):
-            associations = session.query(HAIPAddressToPortAssocation).all()
-        return associations
+        return session.query(HAIPAddressToPortAssocation).all()
 
 
 class HAIPOwnerDbMixin(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # process, which may cause wedges in the gate later.
 
 -e git+https://github.com/noironetworks/apicapi.git@master#egg=apicapi
--e git+https://github.com/noironetworks/python-opflex-agent.git@master#egg=neutron_opflex_agent
+-e git+https://github.com/noironetworks/python-opflex-agent.git@stable/newton#egg=neutron_opflex_agent
 
 # These are needed until the 2.3 Routes is excluded in upstream dependencies
 Routes!=2.0,!=2.1,!=2.3,>=1.12.3;python_version=='2.7' # MIT

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,6 +6,7 @@
 -e git+https://github.com/Mirantis/vmware-dvs.git@master#egg=vmware_dvs
 hacking<0.11,>=0.10.0
 
+neutron-lib<1.0.0
 cliff!=1.16.0,!=1.17.0,>=1.15.0  # Apache-2.0
 coverage>=3.6 # Apache-2.0
 eventlet==0.19.0


### PR DESCRIPTION
Commit 6589961345bfcc5634960f49e158180523d3f324 introduced context
managers for operations that were only for reads, which aren't needed.
This reverts the use of context managers for reads, which also makes
it consistent with the implementation in the upstream group-based-policy repo.

This patch also fixes two issues with requirements.