### PR TITLE
Fix session use for AAPs

### DIFF
--- a/apic_ml2/neutron/db/port_ha_ipaddress_binding.py
+++ b/apic_ml2/neutron/db/port_ha_ipaddress_binding.py
@@ -61,9 +61,9 @@ class PortForHAIPAddress(object):
                     models_v2.Port.network_id == network_id).first()
         return port_ha_ip
 
-    def get_ha_ipaddresses_for_port(self, port_id):
+    def get_ha_ipaddresses_for_port(self, port_id, session=None):
         """Returns the HA IP Addressses associated with a Port."""
-        session = db_api.get_session()
+        session = session or db_api.get_session()
         objs = session.query(HAIPAddressToPortAssocation).filter_by(
             port_id=port_id).all()
         return sorted([x['ha_ip_address'] for x in objs])


### PR DESCRIPTION
The port_ha_ipaddress_binding module is used by the legacy
plugin as well as the unified plugin's stable/newton branch.
Support for use of CIDRs in AAPs was added to the unified
plugin, but not the legacy plugin, which required an API
change for this module. This patch fixes the missing API
change.